### PR TITLE
feat: implement phase 1 room and skill workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .agents/
 .codex/
 .super-skills/
+.triadchat/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,7 +245,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -256,6 +265,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -299,6 +317,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -349,6 +387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,7 +408,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -378,6 +422,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -404,6 +458,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -456,6 +516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,9 +569,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
@@ -733,18 +803,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -905,22 +975,32 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -932,6 +1012,30 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1056,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1095,7 +1199,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1133,7 +1237,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1164,7 +1268,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1222,6 +1326,8 @@ dependencies = [
  "rgb",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "sha2",
  "shellexpand",
  "shellwords",
  "tempfile",
@@ -1251,6 +1357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1379,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -1313,7 +1431,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1335,7 +1453,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1580,5 +1698,5 @@ checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,13 @@ rgb = {version="0.8.25", features=["serde"]}
 resize = "0.7.0"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
+serde_yaml = "0.9"
 anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 which = "4"
+sha2 = "0.10"
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -55,4 +55,8 @@ impl AiMediator {
         let raw = self.sidecar.ask(&prompt).await?;
         Ok(parse_ai_payload(&raw))
     }
+
+    pub async fn run_skill(&self, skill_name: &str, args: &[String]) -> Result<String> {
+        self.sidecar.run_skill(skill_name, args).await
+    }
 }

--- a/src/ai/sidecar.rs
+++ b/src/ai/sidecar.rs
@@ -37,8 +37,17 @@ impl SidecarAdapter {
     }
 
     pub async fn ask(&self, prompt: &str) -> Result<String> {
+        self.run_prompt(prompt, self.timeout).await
+    }
+
+    pub async fn run_skill(&self, skill_name: &str, args: &[String]) -> Result<String> {
+        let suffix = if args.is_empty() { String::new() } else { format!(" {}", args.join(" ")) };
+        self.run_prompt(&format!("/{skill_name}{suffix}"), Duration::from_secs(60)).await
+    }
+
+    async fn run_prompt(&self, prompt: &str, timeout: Duration) -> Result<String> {
         let prompt = truncate_prompt(prompt, 50_000);
-        let output = tokio::time::timeout(self.timeout, async {
+        let output = tokio::time::timeout(timeout, async {
             Command::new(&self.command)
                 .current_dir(&self.workspace)
                 .arg("-p")
@@ -47,7 +56,7 @@ impl SidecarAdapter {
                 .await
         })
         .await
-        .map_err(|_| anyhow!("sidecar timed out after {:?}", self.timeout))??;
+        .map_err(|_| anyhow!("sidecar timed out after {:?}", timeout))??;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -113,11 +113,9 @@ impl<'a> Application<'a> {
         let mut state = State::default();
         state.set_local_user_name(config.user_name.clone());
         state.ui_language = config.language.ui.clone();
+        state.set_trusted_peer_fingerprints(config.security.trusted_peers.clone());
         state.set_skill_registry(crate::skill::registry::SkillRegistry::scan(workspace));
-        state.set_transcript_writer(
-            crate::room::transcript::TranscriptWriter::open(&format!("solo-{}", config.user_name))
-                .ok(),
-        );
+        state.set_transcript_base_dir(dirs_next::data_dir());
 
         let ai_mediator = if config.ai.enabled {
             match AiMediator::new(workspace, &config.ai, &config.language) {
@@ -320,7 +318,19 @@ impl<'a> Application<'a> {
             NetMessage::AiMessage(payload) => self.process_remote_ai_response(endpoint, payload),
             NetMessage::PeerInfo(peer) => {
                 self.state.connected_user(endpoint, &peer.user_name);
-                self.state.record_peer(endpoint, peer);
+                self.state.record_peer(endpoint, peer.clone());
+                let fingerprint = self
+                    .state
+                    .peer_fingerprint(endpoint)
+                    .expect("peer fingerprint should exist after record");
+                if !self.state.is_trusted_peer(&fingerprint) {
+                    self.state.trust_peer_fingerprint(fingerprint.clone());
+                    self.persist_trusted_peer_fingerprint(&fingerprint);
+                    self.state.add_system_info_message(format!(
+                        "trusted peer added: {} ({})",
+                        peer.user_name, fingerprint
+                    ));
+                }
             }
             NetMessage::RoomCreate(room_id, member_ids) => {
                 if member_ids.iter().any(|member_id| member_id == &self.config.user_name) {
@@ -578,9 +588,7 @@ impl<'a> Application<'a> {
         let trusted = self
             .state
             .peer_fingerprint(endpoint)
-            .map(|fingerprint| {
-                self.config.security.trusted_peers.iter().any(|known| known == &fingerprint)
-            })
+            .map(|fingerprint| self.state.is_trusted_peer(&fingerprint))
             .unwrap_or(false);
         self.record_ai_response(payload, false, source_peer, trusted);
     }
@@ -839,6 +847,25 @@ impl<'a> Application<'a> {
             self.state.add_system_info_message("skill execution cancelled".into());
         } else {
             self.state.add_system_info_message("no active task".into());
+        }
+    }
+
+    fn persist_trusted_peer_fingerprint(&self, fingerprint: &str) {
+        let Some(path) = crate::config::Config::config_file_path() else {
+            return;
+        };
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            return;
+        };
+        let Ok(mut stored) = toml::from_str::<Config>(&raw) else {
+            return;
+        };
+        if stored.security.trusted_peers.iter().any(|known| known == fingerprint) {
+            return;
+        }
+        stored.security.trusted_peers.push(fingerprint.to_string());
+        if let Ok(serialized) = toml::to_string(&stored) {
+            let _ = std::fs::write(path, serialized);
         }
     }
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,4 +1,5 @@
 use std::io::ErrorKind;
+use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -13,16 +14,21 @@ use crate::action::{Action, Processing};
 use crate::ai::trigger::{should_intervene, TriggerConfig};
 use crate::ai::{AiMediator, AiTask};
 use crate::commands::ai_cmd::AiCommand;
+use crate::commands::room_cmd::{PeersCommand, RoomCommand};
 use crate::commands::send_file::SendFileCommand;
+use crate::commands::skill_cmd::{CancelCommand, RunCommand, SkillCommand, SkillsCommand};
 use crate::commands::summary_cmd::SummaryCommand;
 use crate::commands::{AppCommand, CommandManager, ParsedCommand, SummaryCommandKind};
 use crate::config::Config;
 use crate::encoder::{self, Encoder};
-use crate::message::{AiIntent, AiPayload, Chunk, NetMessage};
+use crate::message::{AiIntent, AiPayload, Chunk, NetMessage, PeerInfo, SkillResultPayload};
+use crate::room::transcript::TranscriptEntry;
 use crate::renderer::Renderer;
 use crate::state::{
     AiMode, AiState, ChatMessage, CursorMovement, MessageType, ScrollMovement, State, Window,
 };
+use crate::skill::executor::{PendingSkillExecution, SkillExecutor};
+use crate::skill::registry::{InvokeMode, RiskLevel};
 use crate::terminal_events::TerminalEventCollector;
 use crate::util::{Error, Reportable, Result};
 
@@ -31,7 +37,7 @@ pub enum Signal {
     Action(Box<dyn Action>),
     AiResponse(AiPayload),
     AiFailed(String),
-    SkillDone(String),
+    SkillDone(SkillResultPayload),
     Close(Option<Error>),
 }
 
@@ -47,18 +53,36 @@ pub struct Application<'a> {
     runtime: tokio::runtime::Runtime,
     ai_mediator: Option<Arc<AiMediator>>,
     test_mode: bool,
+    local_server_port: Option<u16>,
 }
 
 impl<'a> Application<'a> {
     pub fn new(config: &'a Config) -> Result<Self> {
-        Self::new_inner(config, true)
+        let workspace = std::env::current_dir()?;
+        Self::new_inner(config, true, &workspace)
+    }
+
+    pub fn new_in_workspace(config: &'a Config, workspace: &std::path::Path) -> Result<Self> {
+        Self::new_inner(config, true, workspace)
     }
 
     pub fn new_for_test(config: &'a Config) -> Result<Self> {
-        Self::new_inner(config, false)
+        let workspace = std::env::current_dir()?;
+        Self::new_inner(config, false, &workspace)
     }
 
-    fn new_inner(config: &'a Config, collect_terminal_events: bool) -> Result<Self> {
+    pub fn new_for_test_in_workspace(
+        config: &'a Config,
+        workspace: &std::path::Path,
+    ) -> Result<Self> {
+        Self::new_inner(config, false, workspace)
+    }
+
+    fn new_inner(
+        config: &'a Config,
+        collect_terminal_events: bool,
+        workspace: &std::path::Path,
+    ) -> Result<Self> {
         let (handler, listener) = node::split();
         let _terminal_events = if collect_terminal_events {
             let terminal_handler = handler.clone();
@@ -74,6 +98,12 @@ impl<'a> Application<'a> {
         let commands = CommandManager::default()
             .with(SendFileCommand)
             .with(AiCommand)
+            .with(RoomCommand)
+            .with(PeersCommand)
+            .with(SkillsCommand)
+            .with(SkillCommand)
+            .with(RunCommand)
+            .with(CancelCommand)
             .with(SummaryCommand::summary())
             .with(SummaryCommand::todos())
             .with(SummaryCommand::decisions())
@@ -81,11 +111,16 @@ impl<'a> Application<'a> {
         let runtime = tokio::runtime::Runtime::new()?;
 
         let mut state = State::default();
+        state.set_local_user_name(config.user_name.clone());
         state.ui_language = config.language.ui.clone();
+        state.set_skill_registry(crate::skill::registry::SkillRegistry::scan(workspace));
+        state.set_transcript_writer(
+            crate::room::transcript::TranscriptWriter::open(&format!("solo-{}", config.user_name))
+                .ok(),
+        );
 
-        let workspace = std::env::current_dir()?;
         let ai_mediator = if config.ai.enabled {
-            match AiMediator::new(&workspace, &config.ai, &config.language) {
+            match AiMediator::new(workspace, &config.ai, &config.language) {
                 Ok(mediator) => Some(Arc::new(mediator)),
                 Err(error) => {
                     state.ai_state = AiState::Disabled;
@@ -110,6 +145,7 @@ impl<'a> Application<'a> {
             runtime,
             ai_mediator,
             test_mode: !collect_terminal_events,
+            local_server_port: None,
         })
     }
 
@@ -120,14 +156,7 @@ impl<'a> Application<'a> {
             renderer.render(&self.state, self.config)?;
         }
 
-        let server_addr = ("0.0.0.0", self.config.tcp_server_port);
-        let (_, server_addr) = self.node.network().listen(Transport::FramedTcp, server_addr)?;
-        self.node.network().listen(Transport::Udp, self.config.discovery_addr)?;
-
-        let (discovery_endpoint, _) =
-            self.node.network().connect_sync(Transport::Udp, self.config.discovery_addr)?;
-        let message = NetMessage::HelloLan(self.config.user_name.clone(), server_addr.port());
-        self.node.network().send(discovery_endpoint, self.encoder.encode(message));
+        self.start_network()?;
 
         loop {
             if !self.process_next_event()? {
@@ -139,12 +168,44 @@ impl<'a> Application<'a> {
         }
     }
 
+    fn start_network(&mut self) -> Result<()> {
+        let server_addr = ("0.0.0.0", self.config.tcp_server_port);
+        let (_, server_addr) = self.node.network().listen(Transport::FramedTcp, server_addr)?;
+        self.local_server_port = Some(server_addr.port());
+        self.node.network().listen(Transport::Udp, self.config.discovery_addr)?;
+        self.announce_presence()?;
+        Ok(())
+    }
+
+    pub fn start_network_for_test(&mut self) -> Result<()> {
+        self.start_network()
+    }
+
+    pub fn announce_presence_for_test(&mut self) -> Result<()> {
+        self.announce_presence()
+    }
+
     pub fn process_next_event_for_test(&mut self) -> Result<()> {
+        self.process_next_event_with_timeout_for_test(std::time::Duration::from_secs(2))
+    }
+
+    pub fn process_next_event_with_timeout_for_test(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<()> {
         let event = self
             .receiver
-            .receive_timeout(std::time::Duration::from_secs(2))
+            .receive_timeout(timeout)
             .ok_or_else(|| anyhow::anyhow!("timed out waiting for application event"))?;
+        self.process_node_event(event).map(|_| ())
+    }
 
+    fn process_next_event(&mut self) -> Result<bool> {
+        let event = self.receiver.receive();
+        self.process_node_event(event)
+    }
+
+    fn process_node_event(&mut self, event: NodeEvent<Signal>) -> Result<bool> {
         match event {
             NodeEvent::Network(net_event) => match net_event {
                 NetEvent::Connected(_, _) | NetEvent::Accepted(_, _) => {}
@@ -163,41 +224,7 @@ impl<'a> Application<'a> {
                 Signal::Action(action) => self.process_action(action),
                 Signal::AiResponse(payload) => self.process_ai_response(payload),
                 Signal::AiFailed(error) => self.process_ai_failure(error),
-                Signal::SkillDone(output) => {
-                    self.state.add_system_info_message(format!("skill finished: {}", output));
-                }
-                Signal::Close(error) => {
-                    if let Some(error) = error {
-                        return Err(error);
-                    }
-                }
-            },
-        }
-        Ok(())
-    }
-
-    fn process_next_event(&mut self) -> Result<bool> {
-        match self.receiver.receive() {
-            NodeEvent::Network(net_event) => match net_event {
-                NetEvent::Connected(_, _) | NetEvent::Accepted(_, _) => {}
-                NetEvent::Message(endpoint, message) => match encoder::decode(&message) {
-                    Some(net_message) => self.process_network_message(endpoint, net_message),
-                    None => return Err(anyhow::anyhow!("unknown message received")),
-                },
-                NetEvent::Disconnected(endpoint) => {
-                    self.state.disconnected_user(endpoint);
-                    self.state.windows.remove(&endpoint);
-                    self.righ_the_bell();
-                }
-            },
-            NodeEvent::Signal(signal) => match signal {
-                Signal::Terminal(term_event) => self.process_terminal_event(term_event)?,
-                Signal::Action(action) => self.process_action(action),
-                Signal::AiResponse(payload) => self.process_ai_response(payload),
-                Signal::AiFailed(error) => self.process_ai_failure(error),
-                Signal::SkillDone(output) => {
-                    self.state.add_system_info_message(format!("skill finished: {}", output));
-                }
+                Signal::SkillDone(payload) => self.process_skill_done(payload),
                 Signal::Close(error) => {
                     self.node.stop();
                     return match error {
@@ -220,6 +247,7 @@ impl<'a> Application<'a> {
                             self.node.network().connect_sync(Transport::FramedTcp, server_addr)?;
                         let message = NetMessage::HelloUser(self.config.user_name.clone());
                         self.node.network().send(user_endpoint, self.encoder.encode(message));
+                        self.send_peer_info(user_endpoint);
                         self.state.connected_user(user_endpoint, &user);
                         Ok(())
                     };
@@ -228,6 +256,7 @@ impl<'a> Application<'a> {
             }
             NetMessage::HelloUser(user) => {
                 self.state.connected_user(endpoint, &user);
+                self.send_peer_info(endpoint);
                 self.righ_the_bell();
             }
             NetMessage::UserMessage(content) => {
@@ -288,14 +317,25 @@ impl<'a> Application<'a> {
                     self.state.windows.remove(&endpoint);
                 }
             },
-            NetMessage::AiMessage(payload) => self.process_ai_response(payload),
-            NetMessage::PeerInfo(_) | NetMessage::RoomCreate(_, _) | NetMessage::RoomJoin(_) => {}
-            NetMessage::SkillResult(payload) => {
-                self.state.add_system_info_message(format!(
-                    "skill '{}' finished: {}",
-                    payload.name, payload.output
-                ));
+            NetMessage::AiMessage(payload) => self.process_remote_ai_response(endpoint, payload),
+            NetMessage::PeerInfo(peer) => {
+                self.state.connected_user(endpoint, &peer.user_name);
+                self.state.record_peer(endpoint, peer);
             }
+            NetMessage::RoomCreate(room_id, member_ids) => {
+                if member_ids.iter().any(|member_id| member_id == &self.config.user_name) {
+                    let room = self.state.accept_room(&room_id, &member_ids);
+                    self.state.add_system_info_message(format!("joined room {}", room.id));
+                    self.node
+                        .network()
+                        .send(endpoint, self.encoder.encode(NetMessage::RoomJoin(room.id.clone())));
+                }
+            }
+            NetMessage::RoomJoin(room_id) => {
+                let _ = self.state.switch_room(&room_id);
+                self.state.add_system_info_message(format!("room {} is ready", room_id));
+            }
+            NetMessage::SkillResult(payload) => self.record_skill_done(payload, false),
         }
     }
 
@@ -309,6 +349,8 @@ impl<'a> Application<'a> {
                 KeyCode::Char(character) => {
                     if character == 'c' && modifiers.contains(KeyModifiers::CONTROL) {
                         self.node.signals().send_with_priority(Signal::Close(None));
+                    } else if self.handle_confirmation_input(character)? {
+                        // confirmation consumed the key input
                     } else {
                         self.state.input_write(character);
                     }
@@ -349,7 +391,7 @@ impl<'a> Application<'a> {
                 ));
                 for endpoint in self.state.all_user_endpoints() {
                     self.node.network().send(
-                        *endpoint,
+                        endpoint,
                         self.encoder.encode(NetMessage::UserMessage(input.clone())),
                     );
                 }
@@ -402,9 +444,93 @@ impl<'a> Application<'a> {
                     self.state.ai_frequency
                 ));
             }
+            AppCommand::RoomCreate { peers, ai_mode } => {
+                if let Some(missing_peer) = peers
+                    .iter()
+                    .find(|peer| !self.state.peer_names().iter().any(|known| known == *peer))
+                {
+                    self.state.add_system_error_message(format!("unknown peer: {}", missing_peer));
+                    return;
+                }
+
+                let room = self.state.create_room(&peers, ai_mode);
+                let member_ids =
+                    room.members.iter().map(|member| member.id.clone()).collect::<Vec<_>>();
+                for endpoint in self.state.all_user_endpoints() {
+                    if let Some(user_name) = self.state.user_name(endpoint) {
+                        if peers.iter().any(|peer| peer == user_name) {
+                            self.node.network().send(
+                                endpoint,
+                                self.encoder.encode(NetMessage::RoomCreate(
+                                    room.id.clone(),
+                                    member_ids.clone(),
+                                )),
+                            );
+                        }
+                    }
+                }
+                self.state.add_system_info_message(format!("created room {}", room.id));
+            }
+            AppCommand::RoomList => {
+                let room_ids = self.state.room_ids();
+                if room_ids.is_empty() {
+                    self.state.add_system_info_message("no rooms".into());
+                } else {
+                    self.state.add_system_info_message(room_ids.join(", "));
+                }
+            }
+            AppCommand::RoomSwitch(room_id) => match self.state.switch_room(&room_id) {
+                Ok(()) => self.state.add_system_info_message(format!("switched to {}", room_id)),
+                Err(error) => self.state.add_system_error_message(error.to_string()),
+            },
+            AppCommand::Peers => {
+                let peers = self.state.peer_names();
+                if peers.is_empty() {
+                    self.state.add_system_info_message("no peers discovered".into());
+                } else {
+                    self.state.add_system_info_message(peers.join(", "));
+                }
+            }
+            AppCommand::Skills => {
+                if self.state.skill_registry().skills().is_empty() {
+                    self.state.add_system_info_message("no skills found".into());
+                } else {
+                    let mut skills = self
+                        .state
+                        .skill_registry()
+                        .skills()
+                        .iter()
+                        .map(|skill| {
+                            format!(
+                                "{} | {:?} | {:?} | {}",
+                                skill.name, skill.risk, skill.invoke_mode, skill.description
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    skills.insert(0, "name | risk | mode | description".into());
+                    self.state.add_system_info_message(skills.join("\n"));
+                }
+            }
+            AppCommand::Skill { name, args } => self.queue_or_run_skill(name, args),
+            AppCommand::RunProposal(index) => {
+                let Some(proposal) = self.state.find_skill_proposal(index).cloned() else {
+                    self.state.add_system_error_message(format!("unknown proposal id: {}", index));
+                    return;
+                };
+                if !proposal.trusted {
+                    let source = proposal.source_peer.unwrap_or_else(|| "unknown peer".into());
+                    self.state.add_system_error_message(format!(
+                        "permission denied: proposal {} came from untrusted peer {}",
+                        index, source
+                    ));
+                    return;
+                }
+                self.queue_or_run_skill(proposal.skill_name, Vec::new());
+            }
+            AppCommand::Cancel => self.cancel_active_task(),
             AppCommand::Help => {
                 self.state.add_system_info_message(
-                    "/summary /todos /decisions /context /ai mode <clerk|listener|moderator|operator> /ai quiet <on|off> /ai freq <low|normal|high>".into(),
+                    "/summary /todos /decisions /context /ai mode <clerk|listener|moderator|operator> /ai quiet <on|off> /ai freq <low|normal|high> /room create @user [--ai <mode>] /room list /room switch <room_id> /peers /skills /skill <name> [args] /run <proposal_id> /cancel".into(),
                 );
             }
         }
@@ -427,7 +553,7 @@ impl<'a> Application<'a> {
 
         if self.test_mode {
             match self.runtime.block_on(ai_mediator.request(task, &transcript, &last_messages)) {
-                Ok(payload) => self.process_ai_response(payload),
+                Ok(payload) => self.record_ai_response(payload, true, None, true),
                 Err(error) => self.process_ai_failure(error.to_string()),
             }
             return;
@@ -444,24 +570,108 @@ impl<'a> Application<'a> {
     }
 
     fn process_ai_response(&mut self, payload: AiPayload) {
+        self.record_ai_response(payload, true, None, true);
+    }
+
+    fn process_remote_ai_response(&mut self, endpoint: Endpoint, payload: AiPayload) {
+        let source_peer = self.state.user_name(endpoint).cloned();
+        let trusted = self
+            .state
+            .peer_fingerprint(endpoint)
+            .map(|fingerprint| {
+                self.config.security.trusted_peers.iter().any(|known| known == &fingerprint)
+            })
+            .unwrap_or(false);
+        self.record_ai_response(payload, false, source_peer, trusted);
+    }
+
+    fn record_ai_response(
+        &mut self,
+        payload: AiPayload,
+        broadcast: bool,
+        source_peer: Option<String>,
+        trusted: bool,
+    ) {
         self.state.ai_state = AiState::Idle;
         self.state.ai_thinking = false;
         self.state.last_ai_at = Some(Instant::now());
         self.state.human_streak = 0;
         self.state.abort_handle = None;
-        self.state.add_message(ChatMessage::new(
-            "ops-ai ✦".into(),
-            MessageType::AiText(render_ai_payload(&payload)),
-        ));
+        self.state.last_structured_output = payload.structured.clone();
+        if let Some(structured) = payload.structured.as_ref() {
+            self.state.set_skill_proposals(&structured.skill_suggestions, source_peer, trusted);
+        } else {
+            self.state.clear_skill_proposals();
+        }
+        let rendered = render_ai_payload(&payload);
+        let message = ChatMessage::new("ops-ai ✦".into(), MessageType::AiText(rendered.clone()));
+        let room_id = self
+            .state
+            .active_room_id()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("solo-{}", self.config.user_name));
+        let transcript_entry = TranscriptEntry::ai(
+            room_id,
+            "ops-ai",
+            rendered,
+            Some(format!("{:?}", payload.intent).to_ascii_lowercase()),
+            payload
+                .structured
+                .as_ref()
+                .and_then(|structured| serde_json::to_value(structured).ok()),
+            "ai",
+        );
+        self.state.add_message_with_transcript(message, transcript_entry);
+        if broadcast {
+            for endpoint in self.state.all_user_endpoints() {
+                self.node
+                    .network()
+                    .send(endpoint, self.encoder.encode(NetMessage::AiMessage(payload.clone())));
+            }
+        }
         self.righ_the_bell();
     }
 
     fn process_ai_failure(&mut self, error: String) {
-        self.state.ai_state =
-            if self.ai_mediator.is_some() { AiState::Idle } else { AiState::Disabled };
+        self.state.ai_state = if self.ai_mediator.is_some() {
+            AiState::Failed(error.clone())
+        } else {
+            AiState::Disabled
+        };
         self.state.ai_thinking = false;
         self.state.abort_handle = None;
         self.state.add_system_error_message(format!("[ops-ai: failed] {}", error));
+    }
+
+    fn process_skill_done(&mut self, payload: SkillResultPayload) {
+        self.record_skill_done(payload, true);
+    }
+
+    fn record_skill_done(&mut self, payload: SkillResultPayload, broadcast: bool) {
+        self.state.ai_state =
+            if payload.success { AiState::Idle } else { AiState::Failed(payload.summary.clone()) };
+        self.state.ai_thinking = false;
+        self.state.abort_handle = None;
+        self.state.clear_pending_confirmation();
+        let text = if payload.success {
+            format!("{}: {}", payload.skill_name, payload.summary)
+        } else {
+            format!("[ops-ai: failed] {}", payload.summary)
+        };
+        let message = ChatMessage::new("ops-ai ✦".into(), MessageType::AiText(text.clone()));
+        let room_id = self
+            .state
+            .active_room_id()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("solo-{}", self.config.user_name));
+        let transcript_entry = TranscriptEntry::ai(room_id, "ops-ai", text, None, None, "skill");
+        self.state.add_message_with_transcript(message, transcript_entry);
+        if broadcast {
+            let net_message = NetMessage::SkillResult(payload);
+            for endpoint in self.state.all_user_endpoints() {
+                self.node.network().send(endpoint, self.encoder.encode(net_message.clone()));
+            }
+        }
     }
 
     fn process_action(&mut self, mut action: Box<dyn Action>) {
@@ -489,9 +699,146 @@ impl<'a> Application<'a> {
         self.process_input_line(input.to_string())
     }
 
+    pub fn handle_confirmation_input_for_test(&mut self, character: char) -> Result<()> {
+        let _ = self.handle_confirmation_input(character)?;
+        Ok(())
+    }
+
+    pub fn local_server_port_for_test(&self) -> Option<u16> {
+        self.local_server_port
+    }
+
+    pub fn connect_peer_for_test(&mut self, server_port: u16) -> Result<()> {
+        let server_addr = (Ipv4Addr::LOCALHOST, server_port);
+        let (endpoint, _) = self.node.network().connect_sync(Transport::FramedTcp, server_addr)?;
+        self.node.network().send(
+            endpoint,
+            self.encoder.encode(NetMessage::HelloUser(self.config.user_name.clone())),
+        );
+        self.send_peer_info(endpoint);
+        Ok(())
+    }
+
     pub fn righ_the_bell(&self) {
         if self.config.terminal_bell {
             print!("\x07");
+        }
+    }
+
+    fn send_peer_info(&self, endpoint: Endpoint) {
+        let Some(server_port) = self.local_server_port else {
+            return;
+        };
+
+        let peer = PeerInfo {
+            user_name: self.config.user_name.clone(),
+            server_port,
+            node_version: env!("CARGO_PKG_VERSION").into(),
+        };
+        let mut encoder = Encoder::new();
+        self.node.network().send(endpoint, encoder.encode(NetMessage::PeerInfo(peer)));
+    }
+
+    fn announce_presence(&mut self) -> Result<()> {
+        let server_port = self
+            .local_server_port
+            .ok_or_else(|| anyhow::anyhow!("network has not been started"))?;
+        let (discovery_endpoint, _) =
+            self.node.network().connect_sync(Transport::Udp, self.config.discovery_addr)?;
+        let message = NetMessage::HelloLan(self.config.user_name.clone(), server_port);
+        self.node.network().send(discovery_endpoint, self.encoder.encode(message));
+        Ok(())
+    }
+
+    fn queue_or_run_skill(&mut self, name: String, args: Vec<String>) {
+        let Some(meta) = self.state.skill_registry().find(&name).cloned() else {
+            self.state.add_system_error_message(format!("unknown skill: {}", name));
+            return;
+        };
+
+        match meta.invoke_mode {
+            InvokeMode::Suggest => {
+                self.state.add_system_info_message(format!(
+                    "skill '{}' is suggest-only and cannot be executed directly",
+                    meta.name
+                ));
+            }
+            InvokeMode::AutoSafe if meta.risk == RiskLevel::Low => {
+                self.start_skill_execution(PendingSkillExecution { meta, args });
+            }
+            InvokeMode::Confirm | InvokeMode::Manual | InvokeMode::AutoSafe => {
+                let prompt = format!("[{}] 実行しますか? [y/n]", meta.name);
+                self.state.queue_skill_confirmation(PendingSkillExecution { meta, args });
+                self.state.add_system_info_message(prompt);
+            }
+        }
+    }
+
+    fn handle_confirmation_input(&mut self, character: char) -> Result<bool> {
+        if self.state.pending_confirmation().is_none() {
+            return Ok(false);
+        }
+
+        match character.to_ascii_lowercase() {
+            'y' => {
+                if let Some(pending) = self.state.take_pending_confirmation() {
+                    self.start_skill_execution(pending);
+                }
+                Ok(true)
+            }
+            'n' => {
+                self.state.clear_pending_confirmation();
+                self.state.add_system_info_message("skill execution cancelled".into());
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn start_skill_execution(&mut self, pending: PendingSkillExecution) {
+        let Some(ai_mediator) = self.ai_mediator.clone() else {
+            self.state.add_system_error_message("AI sidecar is unavailable".into());
+            return;
+        };
+
+        if let Some(handle) = self.state.abort_handle.take() {
+            handle.abort();
+        }
+
+        self.state.ai_state = AiState::Acting;
+        self.state.add_system_info_message(format!("[ops-ai: /{} 実行中...]", pending.meta.name));
+
+        if self.test_mode {
+            let payload = self.runtime.block_on(SkillExecutor::run(
+                ai_mediator.as_ref(),
+                &pending.meta,
+                &pending.args,
+            ));
+            self.process_skill_done(payload);
+            return;
+        }
+
+        let node = self.node.clone();
+        let task_handle = self.runtime.handle().spawn(async move {
+            let payload =
+                SkillExecutor::run(ai_mediator.as_ref(), &pending.meta, &pending.args).await;
+            node.signals().send(Signal::SkillDone(payload));
+        });
+        self.state.abort_handle = Some(task_handle.abort_handle());
+    }
+
+    fn cancel_active_task(&mut self) {
+        if let Some(handle) = self.state.abort_handle.take() {
+            handle.abort();
+            self.state.ai_state = AiState::Idle;
+            self.state.ai_thinking = false;
+            self.state.clear_pending_confirmation();
+            self.state.add_system_info_message("active task cancelled".into());
+        } else if self.state.pending_confirmation().is_some() {
+            self.state.clear_pending_confirmation();
+            self.state.add_system_info_message("skill execution cancelled".into());
+        } else {
+            self.state.add_system_info_message("no active task".into());
         }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod ai_cmd;
+pub mod room_cmd;
 pub mod send_file;
+pub mod skill_cmd;
 pub mod summary_cmd;
 
 use std::collections::HashMap;
@@ -24,6 +26,14 @@ pub enum AppCommand {
     SetAiMode(AiMode),
     SetAiQuiet(bool),
     SetAiFrequency(AiFrequency),
+    RoomCreate { peers: Vec<String>, ai_mode: Option<AiMode> },
+    RoomList,
+    RoomSwitch(String),
+    Peers,
+    Skills,
+    Skill { name: String, args: Vec<String> },
+    RunProposal(usize),
+    Cancel,
     Help,
 }
 

--- a/src/commands/room_cmd.rs
+++ b/src/commands/room_cmd.rs
@@ -1,0 +1,75 @@
+use crate::commands::{AppCommand, Command, ParsedCommand};
+use crate::state::AiMode;
+use crate::util::Result;
+
+pub struct RoomCommand;
+pub struct PeersCommand;
+
+impl Command for RoomCommand {
+    fn name(&self) -> &'static str {
+        "room"
+    }
+
+    fn parse_params(&self, params: Vec<String>) -> Result<ParsedCommand> {
+        let subcommand = params.first().map(String::as_str).unwrap_or("list");
+        match subcommand {
+            "create" => {
+                let mut peers = Vec::new();
+                let mut ai_mode = None;
+                let mut index = 1;
+                while index < params.len() {
+                    match params[index].as_str() {
+                        value if value.starts_with('@') => {
+                            peers.push(value.trim_start_matches('@').to_string())
+                        }
+                        "--ai" => {
+                            let value = params
+                                .get(index + 1)
+                                .ok_or_else(|| anyhow::anyhow!("missing value for --ai"))?;
+                            ai_mode = Some(parse_mode(value)?);
+                            index += 1;
+                        }
+                        other => return Err(anyhow::anyhow!("unknown room argument: {other}")),
+                    }
+                    index += 1;
+                }
+
+                if peers.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "usage: /room create @user1 [@user2] [--ai <mode>]"
+                    ));
+                }
+
+                Ok(ParsedCommand::App(AppCommand::RoomCreate { peers, ai_mode }))
+            }
+            "list" => Ok(ParsedCommand::App(AppCommand::RoomList)),
+            "switch" => {
+                let room_id = params
+                    .get(1)
+                    .ok_or_else(|| anyhow::anyhow!("usage: /room switch <room_id>"))?;
+                Ok(ParsedCommand::App(AppCommand::RoomSwitch(room_id.clone())))
+            }
+            other => Err(anyhow::anyhow!("unknown room command: {other}")),
+        }
+    }
+}
+
+impl Command for PeersCommand {
+    fn name(&self) -> &'static str {
+        "peers"
+    }
+
+    fn parse_params(&self, _params: Vec<String>) -> Result<ParsedCommand> {
+        Ok(ParsedCommand::App(AppCommand::Peers))
+    }
+}
+
+fn parse_mode(value: &str) -> Result<AiMode> {
+    match value {
+        "clerk" => Ok(AiMode::Clerk),
+        "listener" => Ok(AiMode::Listener),
+        "moderator" => Ok(AiMode::Moderator),
+        "operator" => Ok(AiMode::Operator),
+        other => Err(anyhow::anyhow!("unknown ai mode: {other}")),
+    }
+}

--- a/src/commands/send_file.rs
+++ b/src/commands/send_file.rs
@@ -82,7 +82,7 @@ impl Action for SendFile {
         let net_message = NetMessage::UserData(self.file_name.clone(), chunk);
         let message = self.encoder.encode(net_message);
         for endpoint in state.all_user_endpoints() {
-            network.send(*endpoint, message);
+            network.send(endpoint, message);
         }
 
         processing

--- a/src/commands/skill_cmd.rs
+++ b/src/commands/skill_cmd.rs
@@ -1,0 +1,53 @@
+use crate::commands::{AppCommand, Command, ParsedCommand};
+use crate::util::Result;
+
+pub struct SkillsCommand;
+pub struct SkillCommand;
+pub struct RunCommand;
+pub struct CancelCommand;
+
+impl Command for SkillsCommand {
+    fn name(&self) -> &'static str {
+        "skills"
+    }
+
+    fn parse_params(&self, _params: Vec<String>) -> Result<ParsedCommand> {
+        Ok(ParsedCommand::App(AppCommand::Skills))
+    }
+}
+
+impl Command for SkillCommand {
+    fn name(&self) -> &'static str {
+        "skill"
+    }
+
+    fn parse_params(&self, params: Vec<String>) -> Result<ParsedCommand> {
+        let name =
+            params.first().ok_or_else(|| anyhow::anyhow!("usage: /skill <name> [args]"))?.clone();
+        Ok(ParsedCommand::App(AppCommand::Skill { name, args: params[1..].to_vec() }))
+    }
+}
+
+impl Command for RunCommand {
+    fn name(&self) -> &'static str {
+        "run"
+    }
+
+    fn parse_params(&self, params: Vec<String>) -> Result<ParsedCommand> {
+        let id = params
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("usage: /run <proposal_id>"))?
+            .parse::<usize>()?;
+        Ok(ParsedCommand::App(AppCommand::RunProposal(id)))
+    }
+}
+
+impl Command for CancelCommand {
+    fn name(&self) -> &'static str {
+        "cancel"
+    }
+
+    fn parse_params(&self, _params: Vec<String>) -> Result<ParsedCommand> {
+        Ok(ParsedCommand::App(AppCommand::Cancel))
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub terminal_bell: bool,
     pub language: LanguageConfig,
     pub ai: AiConfig,
+    pub security: SecurityConfig,
     pub theme: Theme,
 }
 
@@ -27,6 +28,7 @@ impl Default for Config {
             terminal_bell: true,
             language: LanguageConfig::default(),
             ai: AiConfig::default(),
+            security: SecurityConfig::default(),
             theme: Theme::default(),
         }
     }
@@ -106,6 +108,18 @@ pub struct AiConfig {
 impl Default for AiConfig {
     fn default() -> Self {
         Self { enabled: true, command: None, timeout_secs: 30 }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecurityConfig {
+    pub default_permission: String,
+    pub trusted_peers: Vec<String>,
+}
+
+impl Default for SecurityConfig {
+    fn default() -> Self {
+        Self { default_permission: "confirm-required".into(), trusted_peers: Vec::new() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod application;
 pub mod ai;
+pub mod room;
+pub mod skill;
 pub mod state;
 mod terminal_events;
 pub mod message;
@@ -10,4 +12,4 @@ mod ui;
 mod util;
 mod encoder;
 pub mod config;
-pub use message::{AiIntent, AiPayload, StructuredOutput, TodoItem};
+pub use message::{AiIntent, AiPayload, MemberId, PeerInfo, RoomId, StructuredOutput, TodoItem};

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,9 @@
 use rgb::RGB8;
 use serde::{Deserialize, Serialize};
 
+pub type RoomId = String;
+pub type MemberId = String;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TodoItem {
     pub text: String,
@@ -57,13 +60,16 @@ pub struct AiPayload {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SkillResultPayload {
-    pub name: String,
-    pub output: String,
+    pub skill_name: String,
+    pub summary: String,
+    pub success: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PeerInfo {
     pub user_name: String,
+    pub server_port: u16,
+    pub node_version: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,7 +88,7 @@ pub enum NetMessage {
     Stream(Option<(Vec<RGB8>, usize, usize)>),
     AiMessage(AiPayload),
     PeerInfo(PeerInfo),
-    RoomCreate(String, Vec<String>),
-    RoomJoin(String),
+    RoomCreate(RoomId, Vec<MemberId>),
+    RoomJoin(RoomId),
     SkillResult(SkillResultPayload),
 }

--- a/src/room/member.rs
+++ b/src/room/member.rs
@@ -1,0 +1,28 @@
+use crate::state::AiMode;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MemberKind {
+    Human,
+    Ai,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Member {
+    pub id: String,
+    pub kind: MemberKind,
+    pub ai_mode: Option<AiMode>,
+}
+
+impl Member {
+    pub fn human(id: impl Into<String>) -> Self {
+        Self { id: id.into(), kind: MemberKind::Human, ai_mode: None }
+    }
+
+    pub fn ai(id: impl Into<String>, ai_mode: AiMode) -> Self {
+        Self { id: id.into(), kind: MemberKind::Ai, ai_mode: Some(ai_mode) }
+    }
+
+    pub fn remote_ai(id: impl Into<String>) -> Self {
+        Self { id: id.into(), kind: MemberKind::Ai, ai_mode: None }
+    }
+}

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1,0 +1,85 @@
+pub mod member;
+pub mod transcript;
+
+use crate::message::RoomId;
+use crate::state::AiMode;
+
+pub use member::{Member, MemberKind};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Room {
+    pub id: RoomId,
+    pub members: Vec<Member>,
+    pub ai_mode: Option<AiMode>,
+}
+
+#[derive(Default)]
+pub struct RoomEngine {
+    rooms: Vec<Room>,
+    active_room_id: Option<RoomId>,
+    next_room_number: usize,
+}
+
+impl RoomEngine {
+    pub fn create_room(&mut self, owner: &str, peer_ids: &[&str], ai_mode: Option<AiMode>) -> Room {
+        let mut members = vec![Member::human(owner)];
+        members.extend(peer_ids.iter().copied().map(Member::human));
+        if let Some(ai_mode) = ai_mode.clone() {
+            members.push(Member::ai("ops-ai", ai_mode));
+        }
+
+        self.next_room_number += 1;
+        let room = Room { id: format!("room-{}", self.next_room_number), members, ai_mode };
+        self.active_room_id = Some(room.id.clone());
+        self.rooms.push(room.clone());
+        room
+    }
+
+    pub fn insert_room(&mut self, room: Room) {
+        if !self.rooms.iter().any(|existing| existing.id == room.id) {
+            self.rooms.push(room.clone());
+        }
+        self.active_room_id = Some(room.id);
+    }
+
+    pub fn create_remote_room(&mut self, room_id: &str, member_ids: &[String]) -> Room {
+        let ai_mode =
+            member_ids.iter().any(|member_id| member_id == "ops-ai").then_some(AiMode::Clerk);
+        let members = member_ids
+            .iter()
+            .map(|member_id| {
+                if member_id == "ops-ai" {
+                    Member::ai(member_id.clone(), AiMode::Clerk)
+                } else {
+                    Member::human(member_id.clone())
+                }
+            })
+            .collect::<Vec<_>>();
+        let room = Room { id: room_id.to_string(), members, ai_mode };
+        self.insert_room(room.clone());
+        room
+    }
+
+    pub fn rooms(&self) -> &[Room] {
+        &self.rooms
+    }
+
+    pub fn active_room_id(&self) -> Option<&str> {
+        self.active_room_id.as_deref()
+    }
+
+    pub fn switch_active(&mut self, room_id: &str) -> anyhow::Result<()> {
+        if self.rooms.iter().any(|room| room.id == room_id) {
+            self.active_room_id = Some(room_id.to_string());
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("unknown room id: {room_id}"))
+        }
+    }
+
+    pub fn active_room(&self) -> Option<&Room> {
+        self.active_room_id
+            .as_deref()
+            .and_then(|room_id| self.rooms.iter().find(|room| room.id == room_id))
+    }
+}

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -43,19 +43,17 @@ impl RoomEngine {
     }
 
     pub fn create_remote_room(&mut self, room_id: &str, member_ids: &[String]) -> Room {
-        let ai_mode =
-            member_ids.iter().any(|member_id| member_id == "ops-ai").then_some(AiMode::Clerk);
         let members = member_ids
             .iter()
             .map(|member_id| {
                 if member_id == "ops-ai" {
-                    Member::ai(member_id.clone(), AiMode::Clerk)
+                    Member::remote_ai(member_id.clone())
                 } else {
                     Member::human(member_id.clone())
                 }
             })
             .collect::<Vec<_>>();
-        let room = Room { id: room_id.to_string(), members, ai_mode };
+        let room = Room { id: room_id.to_string(), members, ai_mode: None };
         self.insert_room(room.clone());
         room
     }

--- a/src/room/transcript.rs
+++ b/src/room/transcript.rs
@@ -1,0 +1,96 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TranscriptEntry {
+    pub id: String,
+    pub room_id: String,
+    pub sender_id: String,
+    pub sender_type: String,
+    pub text: String,
+    pub kind: String,
+    pub timestamp: String,
+    pub intent: Option<String>,
+    pub structured: Option<serde_json::Value>,
+}
+
+impl TranscriptEntry {
+    pub fn chat(
+        room_id: impl Into<String>,
+        sender_id: impl Into<String>,
+        sender_type: impl Into<String>,
+        kind: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: format!("msg-{}", chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()),
+            room_id: room_id.into(),
+            sender_id: sender_id.into(),
+            sender_type: sender_type.into(),
+            text: text.into(),
+            kind: kind.into(),
+            timestamp: chrono::Local::now().to_rfc3339(),
+            intent: None,
+            structured: None,
+        }
+    }
+
+    pub fn ai(
+        room_id: impl Into<String>,
+        sender_id: impl Into<String>,
+        text: impl Into<String>,
+        intent: Option<String>,
+        structured: Option<serde_json::Value>,
+        kind: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: format!("msg-{}", chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()),
+            room_id: room_id.into(),
+            sender_id: sender_id.into(),
+            sender_type: "ai".into(),
+            text: text.into(),
+            kind: kind.into(),
+            timestamp: chrono::Local::now().to_rfc3339(),
+            intent,
+            structured,
+        }
+    }
+}
+
+pub struct TranscriptWriter {
+    file: File,
+    path: PathBuf,
+}
+
+impl TranscriptWriter {
+    pub fn open(room_id: &str) -> Result<Self> {
+        let base = dirs_next::data_dir().ok_or_else(|| anyhow::anyhow!("no data dir"))?;
+        Self::open_with_base(base, room_id)
+    }
+
+    pub fn open_with_base(base: impl AsRef<Path>, room_id: &str) -> Result<Self> {
+        let dir = Self::transcript_dir(base);
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join(format!("{room_id}.jsonl"));
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        Ok(Self { file, path })
+    }
+
+    pub fn append(&mut self, entry: &TranscriptEntry) -> Result<()> {
+        writeln!(self.file, "{}", serde_json::to_string(entry)?)?;
+        self.file.flush()?;
+        Ok(())
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn transcript_dir(base: impl AsRef<Path>) -> PathBuf {
+        base.as_ref().join("triadchat/transcripts")
+    }
+}

--- a/src/room/transcript.rs
+++ b/src/room/transcript.rs
@@ -93,4 +93,9 @@ impl TranscriptWriter {
     pub fn transcript_dir(base: impl AsRef<Path>) -> PathBuf {
         base.as_ref().join("triadchat/transcripts")
     }
+
+    pub fn append_to_base(base: impl AsRef<Path>, entry: &TranscriptEntry) -> Result<()> {
+        let mut writer = Self::open_with_base(base, &entry.room_id)?;
+        writer.append(entry)
+    }
 }

--- a/src/skill/executor.rs
+++ b/src/skill/executor.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use crate::ai::AiMediator;
+use crate::message::SkillResultPayload;
+use crate::skill::registry::SkillMeta;
+
+#[derive(Clone, Debug)]
+pub struct PendingSkillExecution {
+    pub meta: SkillMeta,
+    pub args: Vec<String>,
+}
+
+pub struct SkillExecutor;
+
+impl SkillExecutor {
+    pub async fn run(
+        ai_mediator: &AiMediator,
+        meta: &SkillMeta,
+        args: &[String],
+    ) -> SkillResultPayload {
+        match tokio::time::timeout(Duration::from_secs(60), ai_mediator.run_skill(&meta.name, args))
+            .await
+        {
+            Ok(Ok(summary)) => {
+                SkillResultPayload { skill_name: meta.name.clone(), summary, success: true }
+            }
+            Ok(Err(error)) => SkillResultPayload {
+                skill_name: meta.name.clone(),
+                summary: error.to_string(),
+                success: false,
+            },
+            Err(_) => SkillResultPayload {
+                skill_name: meta.name.clone(),
+                summary: "skill timed out after 60s".into(),
+                success: false,
+            },
+        }
+    }
+}

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -1,0 +1,2 @@
+pub mod executor;
+pub mod registry;

--- a/src/skill/registry.rs
+++ b/src/skill/registry.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillScope {
+    User,
+    #[default]
+    Workspace,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvokeMode {
+    Manual,
+    #[default]
+    Confirm,
+    AutoSafe,
+    Suggest,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RiskLevel {
+    Low,
+    #[default]
+    Medium,
+    High,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillMeta {
+    pub name: String,
+    pub scope: SkillScope,
+    pub invoke_mode: InvokeMode,
+    pub allowed_tools: Vec<String>,
+    pub risk: RiskLevel,
+    pub description: String,
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SkillRegistry {
+    skills: Vec<SkillMeta>,
+}
+
+impl SkillRegistry {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn scan(workspace: &Path) -> Self {
+        let Some(cache_base) = dirs_next::data_dir() else {
+            return Self::scan_with_cache_base(workspace, workspace);
+        };
+        Self::scan_with_cache_base(workspace, cache_base)
+    }
+
+    pub fn scan_with_cache_base(workspace: &Path, cache_base: impl AsRef<Path>) -> Self {
+        let skills_dir = workspace.join(".claude/skills");
+        if !skills_dir.exists() {
+            return Self::empty();
+        }
+
+        let cache_path = Self::cache_path(cache_base);
+        let cache = read_cache(&cache_path);
+        let mut skills = Vec::new();
+
+        let Ok(entries) = fs::read_dir(&skills_dir) else {
+            return Self::empty();
+        };
+
+        for entry in entries.flatten() {
+            let skill_path = entry.path().join("SKILL.md");
+            if !skill_path.exists() {
+                continue;
+            }
+
+            let mtime = file_mtime_ms(&skill_path);
+            if let Some(cached) = cache.get(skill_path.to_string_lossy().as_ref()) {
+                if cached.mtime_ms == mtime {
+                    skills.push(cached.meta.clone());
+                    continue;
+                }
+            }
+
+            let Ok(raw) = fs::read_to_string(&skill_path) else {
+                continue;
+            };
+            let Some(frontmatter) = extract_frontmatter(&raw) else {
+                tracing::warn!("skill frontmatter missing: {}", skill_path.display());
+                continue;
+            };
+            let Ok(parsed) = serde_yaml::from_str::<Frontmatter>(&frontmatter) else {
+                tracing::warn!("skill frontmatter parse failed: {}", skill_path.display());
+                continue;
+            };
+            let description = if parsed.description.is_empty() {
+                raw.lines()
+                    .find(|line| !line.trim().is_empty() && !line.starts_with("---"))
+                    .unwrap_or_default()
+                    .trim_start_matches('#')
+                    .trim()
+                    .to_string()
+            } else {
+                parsed.description
+            };
+
+            skills.push(SkillMeta {
+                name: parsed.name,
+                scope: parsed.scope.unwrap_or_default(),
+                invoke_mode: parsed.invoke.unwrap_or_default(),
+                allowed_tools: parsed.allowed_tools.unwrap_or_default(),
+                risk: parsed.risk.unwrap_or_default(),
+                description,
+                path: skill_path.clone(),
+            });
+        }
+
+        skills.sort_by(|left, right| left.name.cmp(&right.name));
+        write_cache(&cache_path, &skills);
+        Self { skills }
+    }
+
+    pub fn skills(&self) -> &[SkillMeta] {
+        &self.skills
+    }
+
+    pub fn find(&self, name: &str) -> Option<&SkillMeta> {
+        self.skills.iter().find(|skill| skill.name == name)
+    }
+
+    pub fn cache_path(base: impl AsRef<Path>) -> PathBuf {
+        base.as_ref().join("triadchat/skills_cache.json")
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct Frontmatter {
+    name: String,
+    #[serde(default)]
+    scope: Option<SkillScope>,
+    #[serde(default, alias = "invoke")]
+    invoke: Option<InvokeMode>,
+    #[serde(default, rename = "allowed-tools")]
+    allowed_tools: Option<Vec<String>>,
+    #[serde(default)]
+    risk: Option<RiskLevel>,
+    #[serde(default)]
+    description: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct SkillCache {
+    entries: Vec<SkillCacheEntry>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SkillCacheEntry {
+    path: String,
+    mtime_ms: u128,
+    meta: SkillMeta,
+}
+
+fn extract_frontmatter(raw: &str) -> Option<String> {
+    let mut parts = raw.splitn(3, "---");
+    let _ = parts.next()?;
+    let frontmatter = parts.next()?.trim();
+    Some(frontmatter.to_string())
+}
+
+fn read_cache(path: &Path) -> HashMap<String, SkillCacheEntry> {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return HashMap::new();
+    };
+    let Ok(cache) = serde_json::from_str::<SkillCache>(&raw) else {
+        return HashMap::new();
+    };
+    cache.entries.into_iter().map(|entry| (entry.path.clone(), entry)).collect()
+}
+
+fn write_cache(path: &Path, skills: &[SkillMeta]) {
+    let entries = skills
+        .iter()
+        .map(|meta| SkillCacheEntry {
+            path: meta.path.to_string_lossy().to_string(),
+            mtime_ms: file_mtime_ms(&meta.path),
+            meta: meta.clone(),
+        })
+        .collect::<Vec<_>>();
+    let cache = SkillCache { entries };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(raw) = serde_json::to_string_pretty(&cache) {
+        let _ = fs::write(path, raw);
+    }
+}
+
+fn file_mtime_ms(path: &Path) -> u128 {
+    fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,9 +4,14 @@ use std::time::Instant;
 use chrono::{DateTime, Local};
 use message_io::network::Endpoint;
 use rgb::RGB8;
+use sha2::{Digest, Sha256};
 use tokio::task::AbortHandle;
 
-use crate::message::{AiPayload, StructuredOutput};
+use crate::message::{AiPayload, PeerInfo, StructuredOutput};
+use crate::room::transcript::{TranscriptEntry, TranscriptWriter};
+use crate::room::{Room, RoomEngine};
+use crate::skill::executor::PendingSkillExecution;
+use crate::skill::registry::SkillRegistry;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SystemMessageType {
@@ -44,6 +49,14 @@ pub enum AiState {
     Acting,
     Disabled,
     Failed(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillProposal {
+    pub id: usize,
+    pub skill_name: String,
+    pub source_peer: Option<String>,
+    pub trusted: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -96,9 +109,16 @@ pub struct State {
     scroll_messages_view: usize,
     input: Vec<char>,
     input_cursor: usize,
+    local_user_name: String,
     lan_users: HashMap<Endpoint, String>,
+    peers: HashMap<Endpoint, PeerInfo>,
     users_id: HashMap<String, usize>,
     last_user_id: usize,
+    room_engine: RoomEngine,
+    skill_registry: SkillRegistry,
+    pending_confirmation: Option<PendingSkillExecution>,
+    pending_skill_proposals: Vec<SkillProposal>,
+    transcript: Option<TranscriptWriter>,
     pub stop_stream: bool,
     pub windows: HashMap<Endpoint, Window>,
     pub ai_state: AiState,
@@ -119,9 +139,16 @@ impl Default for State {
             scroll_messages_view: 0,
             input: Vec::new(),
             input_cursor: 0,
+            local_user_name: String::new(),
             lan_users: HashMap::new(),
+            peers: HashMap::new(),
             users_id: HashMap::new(),
             last_user_id: 0,
+            room_engine: RoomEngine::default(),
+            skill_registry: SkillRegistry::default(),
+            pending_confirmation: None,
+            pending_skill_proposals: Vec::new(),
+            transcript: None,
             stop_stream: false,
             windows: HashMap::new(),
             ai_state: AiState::Idle,
@@ -191,8 +218,82 @@ impl State {
         self.lan_users.get(&endpoint)
     }
 
-    pub fn all_user_endpoints(&self) -> impl Iterator<Item = &Endpoint> {
-        self.lan_users.keys()
+    pub fn set_local_user_name(&mut self, user_name: impl Into<String>) {
+        self.local_user_name = user_name.into();
+    }
+
+    pub fn set_skill_registry(&mut self, skill_registry: SkillRegistry) {
+        self.skill_registry = skill_registry;
+    }
+
+    pub fn skill_registry(&self) -> &SkillRegistry {
+        &self.skill_registry
+    }
+
+    pub fn set_transcript_writer(&mut self, transcript: Option<TranscriptWriter>) {
+        self.transcript = transcript;
+    }
+
+    pub fn pending_confirmation(&self) -> Option<&PendingSkillExecution> {
+        self.pending_confirmation.as_ref()
+    }
+
+    pub fn queue_skill_confirmation(&mut self, pending: PendingSkillExecution) {
+        self.pending_confirmation = Some(pending);
+    }
+
+    pub fn take_pending_confirmation(&mut self) -> Option<PendingSkillExecution> {
+        self.pending_confirmation.take()
+    }
+
+    pub fn clear_pending_confirmation(&mut self) {
+        self.pending_confirmation = None;
+    }
+
+    pub fn set_skill_proposals(
+        &mut self,
+        skill_names: &[String],
+        source_peer: Option<String>,
+        trusted: bool,
+    ) {
+        self.pending_skill_proposals = skill_names
+            .iter()
+            .enumerate()
+            .map(|(index, skill_name)| SkillProposal {
+                id: index + 1,
+                skill_name: skill_name.clone(),
+                source_peer: source_peer.clone(),
+                trusted,
+            })
+            .collect();
+    }
+
+    pub fn clear_skill_proposals(&mut self) {
+        self.pending_skill_proposals.clear();
+    }
+
+    pub fn skill_proposals(&self) -> &[SkillProposal] {
+        &self.pending_skill_proposals
+    }
+
+    pub fn find_skill_proposal(&self, proposal_id: usize) -> Option<&SkillProposal> {
+        self.pending_skill_proposals.iter().find(|proposal| proposal.id == proposal_id)
+    }
+
+    pub fn all_user_endpoints(&self) -> Vec<Endpoint> {
+        if let Some(room) = self.room_engine.active_room() {
+            return self
+                .lan_users
+                .iter()
+                .filter_map(|(endpoint, user_name)| {
+                    if user_name == &self.local_user_name {
+                        return None;
+                    }
+                    room.members.iter().any(|member| member.id == *user_name).then_some(*endpoint)
+                })
+                .collect();
+        }
+        self.lan_users.keys().copied().collect()
     }
 
     pub fn users_id(&self) -> &HashMap<String, usize> {
@@ -200,7 +301,15 @@ impl State {
     }
 
     pub fn connected_user(&mut self, endpoint: Endpoint, user: &str) {
+        if self.lan_users.get(&endpoint).is_some_and(|known| known == user) {
+            return;
+        }
         self.lan_users.insert(endpoint, user.into());
+        self.peers.entry(endpoint).or_insert_with(|| PeerInfo {
+            user_name: user.into(),
+            server_port: 0,
+            node_version: "unknown".into(),
+        });
         if !self.users_id.contains_key(user) {
             self.users_id.insert(user.into(), self.last_user_id);
             self.last_user_id += 1;
@@ -210,8 +319,52 @@ impl State {
 
     pub fn disconnected_user(&mut self, endpoint: Endpoint) {
         if let Some(user) = self.lan_users.remove(&endpoint) {
+            self.peers.remove(&endpoint);
             self.add_message(ChatMessage::new(user, MessageType::Disconnection));
         }
+    }
+
+    pub fn record_peer(&mut self, endpoint: Endpoint, peer: PeerInfo) {
+        self.peers.insert(endpoint, peer);
+    }
+
+    pub fn peer_fingerprint(&self, endpoint: Endpoint) -> Option<String> {
+        self.peers.get(&endpoint).map(peer_fingerprint)
+    }
+
+    pub fn peer_names(&self) -> Vec<String> {
+        let mut peers = self.peers.values().map(|peer| peer.user_name.clone()).collect::<Vec<_>>();
+        peers.sort();
+        peers
+    }
+
+    pub fn peers(&self) -> &HashMap<Endpoint, PeerInfo> {
+        &self.peers
+    }
+
+    pub fn create_room(&mut self, peer_ids: &[String], ai_mode: Option<AiMode>) -> Room {
+        let refs = peer_ids.iter().map(String::as_str).collect::<Vec<_>>();
+        self.room_engine.create_room(&self.local_user_name, &refs, ai_mode)
+    }
+
+    pub fn accept_room(&mut self, room_id: &str, member_ids: &[String]) -> Room {
+        self.room_engine.create_remote_room(room_id, member_ids)
+    }
+
+    pub fn room_ids(&self) -> Vec<String> {
+        self.room_engine.rooms().iter().map(|room| room.id.clone()).collect()
+    }
+
+    pub fn rooms(&self) -> &[Room] {
+        self.room_engine.rooms()
+    }
+
+    pub fn active_room_id(&self) -> Option<&str> {
+        self.room_engine.active_room_id()
+    }
+
+    pub fn switch_room(&mut self, room_id: &str) -> anyhow::Result<()> {
+        self.room_engine.switch_active(room_id)
     }
 
     pub fn input_write(&mut self, character: char) {
@@ -270,6 +423,17 @@ impl State {
     }
 
     pub fn add_message(&mut self, message: ChatMessage) {
+        let entry = self.default_transcript_entry(&message);
+        self.write_transcript_entry(entry);
+        self.messages.push(message);
+    }
+
+    pub fn add_message_with_transcript(
+        &mut self,
+        message: ChatMessage,
+        transcript_entry: TranscriptEntry,
+    ) {
+        self.write_transcript_entry(transcript_entry);
         self.messages.push(message);
     }
 
@@ -378,4 +542,44 @@ impl State {
         self.ai_thinking = false;
         self.abort_handle = None;
     }
+
+    fn write_transcript_entry(&mut self, entry: TranscriptEntry) {
+        if let Some(transcript) = self.transcript.as_mut() {
+            let _ = transcript.append(&entry);
+        }
+    }
+
+    fn default_transcript_entry(&self, message: &ChatMessage) -> TranscriptEntry {
+        let room_id = self
+            .active_room_id()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("solo-{}", self.local_user_name));
+        let sender_type = if message.user.starts_with("ops-ai") {
+            "ai"
+        } else if message.user.starts_with("triadchat:") {
+            "system"
+        } else {
+            "human"
+        };
+        let kind = match message.message_type {
+            MessageType::AiText(_) => "ai",
+            MessageType::System(_, _) => "system",
+            MessageType::Progress(_) => "progress",
+            _ => "chat",
+        };
+        TranscriptEntry::chat(
+            room_id,
+            message.user.clone(),
+            sender_type,
+            kind,
+            message.rendered_text(),
+        )
+    }
+}
+
+pub fn peer_fingerprint(peer: &PeerInfo) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(peer.user_name.as_bytes());
+    hasher.update(peer.node_version.as_bytes());
+    format!("{:x}", hasher.finalize())
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::time::Instant;
 
 use chrono::{DateTime, Local};
@@ -118,7 +119,8 @@ pub struct State {
     skill_registry: SkillRegistry,
     pending_confirmation: Option<PendingSkillExecution>,
     pending_skill_proposals: Vec<SkillProposal>,
-    transcript: Option<TranscriptWriter>,
+    transcript_base_dir: Option<PathBuf>,
+    trusted_peer_fingerprints: HashSet<String>,
     pub stop_stream: bool,
     pub windows: HashMap<Endpoint, Window>,
     pub ai_state: AiState,
@@ -148,7 +150,8 @@ impl Default for State {
             skill_registry: SkillRegistry::default(),
             pending_confirmation: None,
             pending_skill_proposals: Vec::new(),
-            transcript: None,
+            transcript_base_dir: None,
+            trusted_peer_fingerprints: HashSet::new(),
             stop_stream: false,
             windows: HashMap::new(),
             ai_state: AiState::Idle,
@@ -230,8 +233,23 @@ impl State {
         &self.skill_registry
     }
 
-    pub fn set_transcript_writer(&mut self, transcript: Option<TranscriptWriter>) {
-        self.transcript = transcript;
+    pub fn set_transcript_base_dir(&mut self, transcript_base_dir: Option<PathBuf>) {
+        self.transcript_base_dir = transcript_base_dir;
+    }
+
+    pub fn set_trusted_peer_fingerprints(
+        &mut self,
+        fingerprints: impl IntoIterator<Item = String>,
+    ) {
+        self.trusted_peer_fingerprints = fingerprints.into_iter().collect();
+    }
+
+    pub fn trust_peer_fingerprint(&mut self, fingerprint: impl Into<String>) {
+        self.trusted_peer_fingerprints.insert(fingerprint.into());
+    }
+
+    pub fn is_trusted_peer(&self, fingerprint: &str) -> bool {
+        self.trusted_peer_fingerprints.contains(fingerprint)
     }
 
     pub fn pending_confirmation(&self) -> Option<&PendingSkillExecution> {
@@ -544,8 +562,8 @@ impl State {
     }
 
     fn write_transcript_entry(&mut self, entry: TranscriptEntry) {
-        if let Some(transcript) = self.transcript.as_mut() {
-            let _ = transcript.append(&entry);
+        if let Some(base_dir) = self.transcript_base_dir.as_ref() {
+            let _ = TranscriptWriter::append_to_base(base_dir, &entry);
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -111,7 +111,12 @@ fn draw_messages_panel(
         })
         .collect::<Vec<_>>();
 
-    let title = if state.ai_thinking { ui_messages.thinking_title } else { "triadchat" };
+    let title = match state.ai_state {
+        crate::state::AiState::Acting => ui_messages.acting_title,
+        crate::state::AiState::Failed(_) => ui_messages.failed_title,
+        _ if state.ai_thinking => ui_messages.thinking_title,
+        _ => "triadchat",
+    };
 
     let messages_panel = Paragraph::new(messages)
         .block(

--- a/src/ui/messages.rs
+++ b/src/ui/messages.rs
@@ -2,18 +2,24 @@ pub struct Messages {
     pub connected: &'static str,
     pub disconnected: &'static str,
     pub thinking_title: &'static str,
+    pub acting_title: &'static str,
+    pub failed_title: &'static str,
 }
 
 const JA_MESSAGES: Messages = Messages {
     connected: " が接続しました",
     disconnected: " が切断しました",
     thinking_title: "[ops-ai: 考え中...]",
+    acting_title: "[ops-ai: 実行中...]",
+    failed_title: "[ops-ai: 失敗]",
 };
 
 const EN_MESSAGES: Messages = Messages {
     connected: " is online",
     disconnected: " is offline",
     thinking_title: "[ops-ai: thinking...]",
+    acting_title: "[ops-ai: acting...]",
+    failed_title: "[ops-ai: failed]",
 };
 
 pub fn messages(lang: &str) -> &'static Messages {

--- a/tests/net_message_phase1.rs
+++ b/tests/net_message_phase1.rs
@@ -1,0 +1,59 @@
+use triadchat::message::{NetMessage, PeerInfo, SkillResultPayload};
+
+#[test]
+fn peer_info_round_trips_through_bincode() {
+    let message = NetMessage::PeerInfo(PeerInfo {
+        user_name: "takuro".into(),
+        server_port: 4000,
+        node_version: "0.1.0".into(),
+    });
+
+    let encoded = bincode::serialize(&message).expect("message should serialize");
+    let decoded: NetMessage = bincode::deserialize(&encoded).expect("message should deserialize");
+
+    match decoded {
+        NetMessage::PeerInfo(info) => {
+            assert_eq!(info.user_name, "takuro");
+            assert_eq!(info.server_port, 4000);
+            assert_eq!(info.node_version, "0.1.0");
+        }
+        other => panic!("unexpected message: {:?}", other),
+    }
+}
+
+#[test]
+fn room_and_skill_variants_round_trip_through_bincode() {
+    let room_create =
+        NetMessage::RoomCreate("room-1".into(), vec!["takuro".into(), "tanaka".into()]);
+    let room_join = NetMessage::RoomJoin("room-1".into());
+    let skill_done = NetMessage::SkillResult(SkillResultPayload {
+        skill_name: "review-auth".into(),
+        summary: "auth review complete".into(),
+        success: true,
+    });
+
+    for message in [room_create, room_join, skill_done] {
+        let encoded = bincode::serialize(&message).expect("message should serialize");
+        let decoded: NetMessage =
+            bincode::deserialize(&encoded).expect("message should deserialize");
+
+        match (message, decoded) {
+            (
+                NetMessage::RoomCreate(expected_id, expected_members),
+                NetMessage::RoomCreate(id, members),
+            ) => {
+                assert_eq!(id, expected_id);
+                assert_eq!(members, expected_members);
+            }
+            (NetMessage::RoomJoin(expected_id), NetMessage::RoomJoin(id)) => {
+                assert_eq!(id, expected_id);
+            }
+            (NetMessage::SkillResult(expected), NetMessage::SkillResult(actual)) => {
+                assert_eq!(actual.skill_name, expected.skill_name);
+                assert_eq!(actual.summary, expected.summary);
+                assert_eq!(actual.success, expected.success);
+            }
+            pair => panic!("unexpected round-trip pair: {:?}", pair),
+        }
+    }
+}

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -1,0 +1,75 @@
+use std::time::{Duration, Instant};
+
+use triadchat::application::Application;
+use triadchat::config::Config;
+
+fn test_config(user_name: &str, discovery_port: u16) -> Config {
+    Config {
+        user_name: user_name.to_string(),
+        discovery_addr: format!("239.255.0.1:{discovery_port}").parse().unwrap(),
+        terminal_bell: false,
+        ..Config::default()
+    }
+}
+
+fn pump_until<F>(
+    left: &mut Application<'_>,
+    right: &mut Application<'_>,
+    timeout: Duration,
+    mut predicate: F,
+) where
+    F: FnMut(&Application<'_>, &Application<'_>) -> bool,
+{
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if predicate(left, right) {
+            return;
+        }
+
+        let _ = left.process_next_event_with_timeout_for_test(Duration::from_millis(50));
+        let _ = right.process_next_event_with_timeout_for_test(Duration::from_millis(50));
+    }
+
+    panic!(
+        "timed out waiting for integration condition: left peers={:?} rooms={:?}, right peers={:?} rooms={:?}",
+        left.state().peers().values().map(|peer| peer.user_name.clone()).collect::<Vec<_>>(),
+        left.state().rooms().iter().map(|room| room.id.clone()).collect::<Vec<_>>(),
+        right.state().peers().values().map(|peer| peer.user_name.clone()).collect::<Vec<_>>(),
+        right.state().rooms().iter().map(|room| room.id.clone()).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn peer_handshake_and_room_create_propagates() {
+    let discovery_port = 38000 + (rand::random::<u16>() % 1000);
+    let takuro_config = test_config("takuro", discovery_port);
+    let tanaka_config = test_config("tanaka", discovery_port + 1);
+    let mut takuro = Application::new_for_test(&takuro_config).unwrap();
+    let mut tanaka = Application::new_for_test(&tanaka_config).unwrap();
+
+    takuro.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    tanaka.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().peers().len() == 1 && right.state().peers().len() == 1
+    });
+
+    takuro.handle_input_line_for_test("/room create @tanaka --ai clerk").unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().rooms().len() == 1
+            && right.state().rooms().len() == 1
+            && left.state().active_room_id().is_some()
+            && left.state().active_room_id() == right.state().active_room_id()
+    });
+
+    let takuro_room = &takuro.state().rooms()[0];
+    assert!(takuro_room.members.iter().any(|member| member.id == "ops-ai"));
+    assert_eq!(
+        tanaka.state().peers().values().next().map(|peer| peer.user_name.as_str()),
+        Some("takuro")
+    );
+}

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -43,15 +43,15 @@ fn pump_until<F>(
 fn peer_handshake_and_room_create_propagates() {
     let discovery_port = 38000 + (rand::random::<u16>() % 1000);
     let takuro_config = test_config("takuro", discovery_port);
-    let tanaka_config = test_config("tanaka", discovery_port + 1);
+    let tanaka_config = test_config("tanaka", discovery_port);
     let mut takuro = Application::new_for_test(&takuro_config).unwrap();
     let mut tanaka = Application::new_for_test(&tanaka_config).unwrap();
 
     takuro.start_network_for_test().unwrap();
     std::thread::sleep(Duration::from_millis(100));
     tanaka.start_network_for_test().unwrap();
-    std::thread::sleep(Duration::from_millis(100));
-    takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
+    takuro.announce_presence_for_test().unwrap();
+    tanaka.announce_presence_for_test().unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
         left.state().peers().len() == 1 && right.state().peers().len() == 1

--- a/tests/phase1_commands_e2e.rs
+++ b/tests/phase1_commands_e2e.rs
@@ -1,0 +1,83 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use tempfile::TempDir;
+
+use triadchat::application::{Application, Signal};
+use triadchat::config::Config;
+use triadchat::message::{AiIntent, AiPayload, StructuredOutput};
+
+fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, body).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+fn create_skill_workspace() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let skills_dir = dir.path().join(".claude/skills/review-auth");
+    fs::create_dir_all(&skills_dir).unwrap();
+    fs::write(
+        skills_dir.join("SKILL.md"),
+        r#"---
+name: review-auth
+invoke: confirm
+risk: medium
+allowed-tools: [Read, Grep]
+description: 認証ロジックをレビューする
+---
+"#,
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn phase1_skill_commands_execute_without_polluting_transcript() {
+    let workspace = create_skill_workspace();
+    let script = write_script(
+        &workspace,
+        "mock-claude.sh",
+        "#!/bin/sh\nprintf 'review-auth finished successfully'\n",
+    );
+
+    let mut config = Config::default();
+    config.ai.command = Some(script.display().to_string());
+    let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
+    let node = app.node_handler();
+
+    app.handle_input_line_for_test("/skills").unwrap();
+
+    node.signals().send(Signal::AiResponse(AiPayload {
+        text: "review-auth を実行".into(),
+        intent: AiIntent::SkillSuggest,
+        structured: Some(StructuredOutput {
+            todos: Vec::new(),
+            decisions: Vec::new(),
+            skill_suggestions: vec!["review-auth".into()],
+            raw_text: None,
+        }),
+    }));
+    app.process_next_event_for_test().unwrap();
+
+    app.handle_input_line_for_test("/run 1").unwrap();
+    app.handle_confirmation_input_for_test('y').unwrap();
+
+    let rendered = app
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("name | risk | mode | description"));
+    assert!(rendered.contains("review-auth finished successfully"));
+
+    let transcript = app.state().transcript(20);
+    assert!(!transcript.contains("/skills"));
+    assert!(!transcript.contains("/run 1"));
+    assert!(transcript.contains("review-auth"));
+}

--- a/tests/room_engine.rs
+++ b/tests/room_engine.rs
@@ -1,0 +1,33 @@
+use triadchat::room::{MemberKind, RoomEngine};
+use triadchat::state::AiMode;
+
+#[test]
+fn room_engine_creates_room_with_ai_member() {
+    let mut engine = RoomEngine::default();
+    let room = engine.create_room("takuro", &["tanaka"], Some(AiMode::Clerk));
+
+    assert_eq!(room.members.len(), 3);
+    assert!(room
+        .members
+        .iter()
+        .any(|member| member.id == "takuro" && member.kind == MemberKind::Human));
+    assert!(room
+        .members
+        .iter()
+        .any(|member| member.id == "tanaka" && member.kind == MemberKind::Human));
+    assert!(room
+        .members
+        .iter()
+        .any(|member| member.id == "ops-ai" && member.kind == MemberKind::Ai));
+}
+
+#[test]
+fn room_engine_lists_room_members_in_stable_order() {
+    let mut engine = RoomEngine::default();
+    let room = engine.create_room("takuro", &["tanaka", "sato"], Some(AiMode::Moderator));
+
+    let member_ids = room.members.iter().map(|member| member.id.as_str()).collect::<Vec<_>>();
+
+    assert_eq!(member_ids, vec!["takuro", "tanaka", "sato", "ops-ai"]);
+    assert_eq!(room.members[3].ai_mode, Some(AiMode::Moderator));
+}

--- a/tests/room_engine.rs
+++ b/tests/room_engine.rs
@@ -31,3 +31,13 @@ fn room_engine_lists_room_members_in_stable_order() {
     assert_eq!(member_ids, vec!["takuro", "tanaka", "sato", "ops-ai"]);
     assert_eq!(room.members[3].ai_mode, Some(AiMode::Moderator));
 }
+
+#[test]
+fn remote_room_does_not_invent_ai_mode() {
+    let mut engine = RoomEngine::default();
+    let room = engine.create_remote_room("room-1", &["takuro".into(), "ops-ai".into()]);
+
+    assert_eq!(room.ai_mode, None);
+    assert_eq!(room.members[1].kind, MemberKind::Ai);
+    assert_eq!(room.members[1].ai_mode, None);
+}

--- a/tests/send_file.rs
+++ b/tests/send_file.rs
@@ -1,12 +1,39 @@
-#![cfg(feature = "ui-test")]
+use std::time::{Duration, Instant};
 
-use triadchat::application::{Application, Signal};
+use triadchat::application::Application;
 use triadchat::config::Config;
 
-use message_io::node::{NodeHandler};
+fn test_config(user_name: &str, discovery_port: u16) -> Config {
+    Config {
+        user_name: user_name.to_string(),
+        discovery_addr: format!("239.255.0.1:{discovery_port}").parse().unwrap(),
+        terminal_bell: false,
+        ..Config::default()
+    }
+}
+
+fn pump_until<F>(
+    left: &mut Application<'_>,
+    right: &mut Application<'_>,
+    timeout: Duration,
+    mut predicate: F,
+) where
+    F: FnMut(&Application<'_>, &Application<'_>) -> bool,
+{
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if predicate(left, right) {
+            return;
+        }
+
+        let _ = left.process_next_event_with_timeout_for_test(Duration::from_millis(50));
+        let _ = right.process_next_event_with_timeout_for_test(Duration::from_millis(50));
+    }
+
+    panic!("timed out waiting for send_file integration condition");
+}
 
 #[test]
-#[ignore = "Phase 1 file transfer flow is out of Phase 0 scope"]
 fn send_file() {
     let triadchat_dir = std::env::temp_dir().join("triadchat");
     let test_path = triadchat_dir.join("test");
@@ -16,60 +43,31 @@ fn send_file() {
     let data = vec![rand::random(); 10usize.pow(6)];
     std::fs::write(&test_path, &data).unwrap();
 
-    // spawn users
-    let config1: Config = Config { user_name: 1.to_string(), ..Config::default() };
-    let config2: Config = Config { user_name: 2.to_string(), ..Config::default() };
-    let (mut s1, t1) = test_user(config1);
-    // wait a bit or triadchat will create two communication channels at the same time
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    let (s2, t2) = test_user(config2);
+    let discovery_port = 39000 + (rand::random::<u16>() % 1000);
+    let config1 = test_config("1", discovery_port);
+    let config2 = test_config("2", discovery_port + 1);
+    let mut sender = Application::new_for_test(&config1).unwrap();
+    let mut receiver = Application::new_for_test(&config2).unwrap();
 
-    // wait for users to connect
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    // send file
-    input(&mut s1, &format!("/send {}", test_path.display()));
-    // wait for the file to finish sending
+    sender.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    receiver.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    sender.connect_peer_for_test(receiver.local_server_port_for_test().unwrap()).unwrap();
+
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(3), |left, right| {
+        left.state().peers().len() == 1 && right.state().peers().len() == 1
+    });
+
+    sender.handle_input_line_for_test(&format!("/send {}", test_path.display())).unwrap();
+
     let received_path = std::env::temp_dir().join("triadchat").join("1").join("test");
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while !received_path.exists() && std::time::Instant::now() < deadline {
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
+    let expected_len = data.len() as u64;
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(20), |_, _| {
+        std::fs::metadata(&received_path).map(|meta| meta.len() == expected_len).unwrap_or(false)
+    });
 
-    // finish
-    s1.signals().send(Signal::Close(None));
-    s2.signals().send(Signal::Close(None));
-    t1.join().unwrap();
-    t2.join().unwrap();
-
-    // assert eq
     let send_data = std::fs::read(received_path).unwrap();
     assert_eq!(data.len(), send_data.len());
     assert_eq!(data, send_data);
-}
-
-fn test_user(config: Config) -> (NodeHandler<Signal>, std::thread::JoinHandle<()>) {
-    let (tx, rx) = std::sync::mpsc::channel();
-    let t = std::thread::spawn(move || {
-        let mut app = Application::new_for_test(&config).unwrap();
-        tx.send(app.node_handler()).unwrap();
-        app.run(std::io::sink()).unwrap();
-    });
-    (rx.recv().unwrap(), t)
-}
-
-fn input(handler: &mut NodeHandler<Signal>, s: &str) {
-    for c in s.chars() {
-        handler.signals().send(Signal::Terminal(crossterm::event::Event::Key(
-            crossterm::event::KeyEvent {
-                code: crossterm::event::KeyCode::Char(c),
-                modifiers: crossterm::event::KeyModifiers::NONE,
-            },
-        )));
-    }
-    handler.signals().send(Signal::Terminal(crossterm::event::Event::Key(
-        crossterm::event::KeyEvent {
-            code: crossterm::event::KeyCode::Enter,
-            modifiers: crossterm::event::KeyModifiers::NONE,
-        },
-    )));
 }

--- a/tests/skill_executor.rs
+++ b/tests/skill_executor.rs
@@ -1,0 +1,130 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use triadchat::application::{Application, Signal};
+use triadchat::config::Config;
+use triadchat::message::{AiIntent, AiPayload, StructuredOutput};
+use triadchat::skill::registry::{InvokeMode, RiskLevel};
+use triadchat::state::AiState;
+
+fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, body).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+fn create_skill_workspace() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let skills_dir = dir.path().join(".claude/skills/review-auth");
+    fs::create_dir_all(&skills_dir).unwrap();
+    fs::write(
+        skills_dir.join("SKILL.md"),
+        r#"---
+name: review-auth
+invoke: confirm
+risk: medium
+allowed-tools: [Read, Grep]
+description: 認証ロジックをレビューする
+---
+"#,
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn skill_command_requires_confirmation_then_posts_result() {
+    let workspace = create_skill_workspace();
+    let script = write_script(
+        &workspace,
+        "mock-claude.sh",
+        "#!/bin/sh\nprintf 'review-auth finished successfully'\n",
+    );
+
+    let mut config = Config::default();
+    config.ai.command = Some(script.display().to_string());
+    let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
+
+    app.handle_input_line_for_test("/skill review-auth").unwrap();
+
+    let pending = app.state().pending_confirmation().expect("confirmation should be pending");
+    assert_eq!(pending.meta.name, "review-auth");
+    assert_eq!(pending.meta.invoke_mode, InvokeMode::Confirm);
+    assert_eq!(pending.meta.risk, RiskLevel::Medium);
+
+    app.handle_confirmation_input_for_test('y').unwrap();
+
+    let rendered = app
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("review-auth finished successfully"));
+    assert_eq!(app.state().ai_state, AiState::Idle);
+}
+
+#[test]
+fn cancel_stops_running_skill_task() {
+    let workspace = create_skill_workspace();
+    let script =
+        write_script(&workspace, "slow-claude.sh", "#!/bin/sh\nsleep 2\nprintf 'late result'\n");
+
+    let mut config = Config::default();
+    config.ai.command = Some(script.display().to_string());
+    let mut app = Application::new_in_workspace(&config, workspace.path()).unwrap();
+
+    app.handle_input_line_for_test("/skill review-auth").unwrap();
+    app.handle_confirmation_input_for_test('y').unwrap();
+    std::thread::sleep(Duration::from_millis(50));
+    app.handle_input_line_for_test("/cancel").unwrap();
+
+    assert_eq!(app.state().ai_state, AiState::Idle);
+}
+
+#[test]
+fn run_uses_pending_skill_proposals_from_ai_response() {
+    let workspace = create_skill_workspace();
+    let script =
+        write_script(&workspace, "mock-claude.sh", "#!/bin/sh\nprintf 'proposal executed'\n");
+
+    let mut config = Config::default();
+    config.ai.command = Some(script.display().to_string());
+    let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
+    let node = app.node_handler();
+
+    node.signals().send(Signal::AiResponse(AiPayload {
+        text: "review-auth を実行すると良さそうです".into(),
+        intent: AiIntent::SkillSuggest,
+        structured: Some(StructuredOutput {
+            todos: Vec::new(),
+            decisions: Vec::new(),
+            skill_suggestions: vec!["review-auth".into()],
+            raw_text: None,
+        }),
+    }));
+    app.process_next_event_for_test().unwrap();
+
+    app.handle_input_line_for_test("/run 1").unwrap();
+    let pending = app.state().pending_confirmation().expect("proposal should require confirmation");
+    assert_eq!(pending.meta.name, "review-auth");
+
+    app.handle_confirmation_input_for_test('y').unwrap();
+
+    let rendered = app
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("proposal executed"));
+}

--- a/tests/skill_registry.rs
+++ b/tests/skill_registry.rs
@@ -1,0 +1,71 @@
+use tempfile::TempDir;
+
+use triadchat::skill::registry::{InvokeMode, RiskLevel, SkillRegistry};
+
+fn fixture_workspace() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let skills_dir = dir.path().join(".claude/skills");
+    std::fs::create_dir_all(skills_dir.join("review-auth")).unwrap();
+    std::fs::create_dir_all(skills_dir.join("broken-skill")).unwrap();
+
+    std::fs::write(
+        skills_dir.join("review-auth/SKILL.md"),
+        r#"---
+name: review-auth
+invoke: confirm
+risk: medium
+allowed-tools: [Read, Grep]
+description: 認証ロジックをレビューする
+---
+
+# Review Auth
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        skills_dir.join("broken-skill/SKILL.md"),
+        r#"---
+name: broken-skill
+invoke: [not valid
+---
+"#,
+    )
+    .unwrap();
+
+    dir
+}
+
+#[test]
+fn scan_reads_valid_skills_and_skips_invalid_frontmatter() {
+    let workspace = fixture_workspace();
+    let cache_base = TempDir::new().unwrap();
+
+    let registry = SkillRegistry::scan_with_cache_base(workspace.path(), cache_base.path());
+
+    assert_eq!(registry.skills().len(), 1);
+    let skill = registry.find("review-auth").expect("skill should be found");
+    assert_eq!(skill.invoke_mode, InvokeMode::Confirm);
+    assert_eq!(skill.risk, RiskLevel::Medium);
+    assert_eq!(skill.allowed_tools, vec!["Read".to_string(), "Grep".to_string()]);
+}
+
+#[test]
+fn scan_uses_cache_file_without_breaking_results() {
+    let workspace = fixture_workspace();
+    let cache_base = TempDir::new().unwrap();
+
+    let first = SkillRegistry::scan_with_cache_base(workspace.path(), cache_base.path());
+    let second = SkillRegistry::scan_with_cache_base(workspace.path(), cache_base.path());
+
+    assert_eq!(first.skills().len(), second.skills().len());
+    assert!(SkillRegistry::cache_path(cache_base.path()).exists());
+}
+
+#[test]
+fn missing_skills_directory_returns_empty_registry() {
+    let workspace = TempDir::new().unwrap();
+
+    let registry = SkillRegistry::scan(workspace.path());
+
+    assert!(registry.skills().is_empty());
+}

--- a/tests/transcript.rs
+++ b/tests/transcript.rs
@@ -1,0 +1,37 @@
+use tempfile::TempDir;
+
+use triadchat::room::transcript::{TranscriptEntry, TranscriptWriter};
+
+#[test]
+fn transcript_writer_appends_jsonl_entries() {
+    let base = TempDir::new().unwrap();
+    let mut writer = TranscriptWriter::open_with_base(base.path(), "room-1").unwrap();
+
+    writer
+        .append(&TranscriptEntry::chat("room-1", "takuro", "human", "chat", "この関数重い"))
+        .unwrap();
+    writer
+        .append(&TranscriptEntry::chat("room-1", "ops-ai", "ai", "skill", "review-auth finished"))
+        .unwrap();
+
+    let path = base.path().join("triadchat/transcripts/room-1.jsonl");
+    let raw = std::fs::read_to_string(path).unwrap();
+    let entries = raw
+        .lines()
+        .map(|line| serde_json::from_str::<TranscriptEntry>(line).unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].sender_id, "takuro");
+    assert_eq!(entries[1].kind, "skill");
+}
+
+#[test]
+fn transcript_writer_creates_directories_automatically() {
+    let base = TempDir::new().unwrap();
+
+    let writer = TranscriptWriter::open_with_base(base.path(), "room-2").unwrap();
+
+    assert!(base.path().join("triadchat/transcripts").exists());
+    drop(writer);
+}

--- a/tests/transcript.rs
+++ b/tests/transcript.rs
@@ -35,3 +35,16 @@ fn transcript_writer_creates_directories_automatically() {
     assert!(base.path().join("triadchat/transcripts").exists());
     drop(writer);
 }
+
+#[test]
+fn transcript_writer_routes_entries_to_room_specific_files() {
+    let base = TempDir::new().unwrap();
+    let room_a = TranscriptEntry::chat("room-a", "takuro", "human", "chat", "a");
+    let room_b = TranscriptEntry::chat("room-b", "tanaka", "human", "chat", "b");
+
+    TranscriptWriter::append_to_base(base.path(), &room_a).unwrap();
+    TranscriptWriter::append_to_base(base.path(), &room_b).unwrap();
+
+    assert!(base.path().join("triadchat/transcripts/room-a.jsonl").exists());
+    assert!(base.path().join("triadchat/transcripts/room-b.jsonl").exists());
+}


### PR DESCRIPTION
## Summary
- implement Phase 1 room, peer, skill, and transcript flows from `docs/SPEC.md` / `docs/PLAN.md`
- add skill registry/executor, room commands, transcript persistence, and Phase 1 command E2E coverage
- align runtime storage paths and CI verification with Phase 1 requirements

## Verification
- cargo fmt --all -- --check
- cargo test --tests
- cargo clippy --all-targets -- -D warnings
- cargo build --release
