### PR TITLE
feat: Room List panel in left column

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -391,6 +391,12 @@ impl<'a> Application<'a> {
                 KeyCode::Right => self.state.input_move_cursor(CursorMovement::Right),
                 KeyCode::Home => self.state.input_move_cursor(CursorMovement::Start),
                 KeyCode::End => self.state.input_move_cursor(CursorMovement::End),
+                KeyCode::Up if modifiers.contains(KeyModifiers::ALT) => {
+                    self.state.scroll_room_list(ScrollMovement::Up);
+                }
+                KeyCode::Down if modifiers.contains(KeyModifiers::ALT) => {
+                    self.state.scroll_room_list(ScrollMovement::Down);
+                }
                 KeyCode::Up => self.state.messages_scroll(ScrollMovement::Up),
                 KeyCode::Down => self.state.messages_scroll(ScrollMovement::Down),
                 KeyCode::PageUp => self.state.messages_scroll(ScrollMovement::Start),

--- a/src/state.rs
+++ b/src/state.rs
@@ -455,11 +455,11 @@ impl State {
     pub fn scroll_room_list(&mut self, movement: ScrollMovement) {
         match movement {
             ScrollMovement::Up => {
-                if self.room_list_scroll > 0 {
-                    self.room_list_scroll -= 1;
-                }
+                self.room_list_scroll = self.room_list_scroll.saturating_sub(1);
             }
-            ScrollMovement::Down => self.room_list_scroll += 1,
+            ScrollMovement::Down => {
+                self.room_list_scroll = self.room_list_scroll.saturating_add(1);
+            }
             ScrollMovement::Start => {}
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -139,6 +139,7 @@ pub struct State {
     pub ai_avatar: String,
     /// Global avatar size hint.
     pub avatar_size: AvatarSize,
+    room_list_scroll: usize,
 }
 
 impl Default for State {
@@ -173,6 +174,7 @@ impl Default for State {
             user_avatar: "human_default".into(),
             ai_avatar: "ai_default".into(),
             avatar_size: AvatarSize::Normal,
+            room_list_scroll: 0,
         }
     }
 }
@@ -444,6 +446,26 @@ impl State {
             ScrollMovement::Down => self.scroll_messages_view += 1,
             ScrollMovement::Start => self.scroll_messages_view += 0,
         }
+    }
+
+    pub fn room_list_scroll(&self) -> usize {
+        self.room_list_scroll
+    }
+
+    pub fn scroll_room_list(&mut self, movement: ScrollMovement) {
+        match movement {
+            ScrollMovement::Up => {
+                if self.room_list_scroll > 0 {
+                    self.room_list_scroll -= 1;
+                }
+            }
+            ScrollMovement::Down => self.room_list_scroll += 1,
+            ScrollMovement::Start => {}
+        }
+    }
+
+    pub fn reset_room_list_scroll(&mut self) {
+        self.room_list_scroll = 0;
     }
 
     pub fn reset_input(&mut self) -> Option<String> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,7 @@
 pub mod layout;
 pub mod messages;
 pub mod peers_panel;
+pub mod room_list_panel;
 pub mod status_panel;
 
 use resize::px::RGB;
@@ -21,6 +22,7 @@ use crate::state::{MessageType, ProgressState, State, SystemMessageType, Window}
 use crate::ui::layout::should_show_side_panels;
 use crate::ui::messages::messages;
 use crate::ui::peers_panel::draw_peers_panel;
+use crate::ui::room_list_panel::draw_room_list_panel;
 use crate::ui::status_panel::draw_status_panel;
 use crate::util::split_each;
 
@@ -40,13 +42,36 @@ pub fn draw(
     let upper_chunk = v_chunks[0];
 
     if should_show_side_panels(chunk.width) {
-        // ── 3-pane layout ──────────────────────────────────────────────────
+        // ── Wide layout ────────────────────────────────────────────────────
+        //
+        //  ┌──────────┬───────────────┬──────────┐
+        //  │  Peers   │     Chat      │  ops-ai  │
+        //  ├──────────┤               │          │
+        //  │  Rooms   │               │          │
+        //  ├──────────┴───────────────┴──────────┤
+        //  │               Input                 │
+        //  └─────────────────────────────────────┘
+        //
+        // Horizontal: left column(18) | chat(min) | status(22)
         let h_chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(layout::three_pane_constraints())
             .split(upper_chunk);
 
-        draw_peers_panel(frame, state, h_chunks[0]);
+        // Left column: peers(min) above, rooms(scaled) below
+        let left_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(layout::left_column_constraints(upper_chunk.height))
+            .split(h_chunks[0]);
+
+        draw_peers_panel(frame, state, left_chunks[0]);
+        draw_room_list_panel(
+            frame,
+            state.rooms(),
+            state.active_room_id(),
+            state.room_list_scroll(),
+            left_chunks[1],
+        );
 
         if !state.windows.is_empty() {
             let chat_chunks = Layout::default()

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -12,9 +12,9 @@ pub fn should_show_side_panels(cols: u16) -> bool {
 }
 
 /// Returns vertical constraints for the left column: [peers(min), rooms(height)].
-/// The rooms panel height is at least 8, and scales to 40% of terminal height above 30.
+/// The rooms panel height is at least 8 (clamped to available height), scaling to 40% above 30.
 pub fn left_column_constraints(left_height: u16) -> Vec<Constraint> {
-    let rooms_height = if left_height > 30 { left_height * 2 / 5 } else { 8 };
+    let rooms_height = if left_height > 30 { left_height * 2 / 5 } else { left_height.min(8) };
     vec![Constraint::Min(0), Constraint::Length(rooms_height)]
 }
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -11,6 +11,13 @@ pub fn should_show_side_panels(cols: u16) -> bool {
     cols >= 80
 }
 
+/// Returns vertical constraints for the left column: [peers(min), rooms(height)].
+/// The rooms panel height is at least 8, and scales to 40% of terminal height above 30.
+pub fn left_column_constraints(left_height: u16) -> Vec<Constraint> {
+    let rooms_height = if left_height > 30 { left_height * 2 / 5 } else { 8 };
+    vec![Constraint::Min(0), Constraint::Length(rooms_height)]
+}
+
 /// Truncates a string to `max_chars` Unicode scalar values.
 pub fn truncate(s: &str, max_chars: usize) -> String {
     s.chars().take(max_chars).collect()

--- a/src/ui/room_list_panel.rs
+++ b/src/ui/room_list_panel.rs
@@ -1,0 +1,86 @@
+use tui::backend::CrosstermBackend;
+use tui::layout::Rect;
+use tui::style::{Modifier, Style};
+use tui::text::Span;
+use tui::widgets::{Block, Borders, Paragraph};
+use tui::Frame;
+
+use std::io::Write;
+
+use crate::room::Room;
+use crate::ui::layout::truncate;
+
+const ID_MAX: usize = 8;
+const MEMBER_NAME_MAX: usize = 6;
+const MEMBER_LINE_MAX: usize = 14;
+const MODE_MAX: usize = 6;
+
+/// Builds the display lines for the room list panel (pure function, easily testable).
+///
+/// Returns 2 lines per room (after applying scroll offset):
+/// - Line 1: `[marker][id:8] [mode:6]`
+/// - Line 2: `  [members, comma-separated, total ≤14 chars]`
+///
+/// `scroll` skips that many lines from the top of the full rendered list.
+pub fn build_room_lines(rooms: &[Room], active_id: Option<&str>, scroll: usize) -> Vec<String> {
+    if rooms.is_empty() {
+        return vec!["  (no rooms)".to_string()];
+    }
+
+    let mut lines: Vec<String> = Vec::with_capacity(rooms.len() * 2);
+
+    for room in rooms {
+        let marker = if active_id == Some(room.id.as_str()) { "* " } else { "  " };
+        let id = truncate(&room.id, ID_MAX);
+        let mode = room
+            .ai_mode
+            .as_ref()
+            .map(|m| format!(" {:.*}", MODE_MAX, format!("{:?}", m).to_lowercase()))
+            .unwrap_or_default();
+        lines.push(format!("{}{}{}", marker, id, mode));
+
+        // Member line: exclude ops-ai, truncate each name, cap total length
+        use crate::room::MemberKind;
+        let mut member_str = String::new();
+        for member in &room.members {
+            if member.kind == MemberKind::Ai && member.id == "ops-ai" {
+                continue;
+            }
+            let name = truncate(&member.id, MEMBER_NAME_MAX);
+            if member_str.is_empty() {
+                member_str.push_str(&name);
+            } else {
+                let candidate = format!("{} {}", member_str, name);
+                if candidate.len() <= MEMBER_LINE_MAX {
+                    member_str = candidate;
+                } else {
+                    break;
+                }
+            }
+        }
+        lines.push(format!("  {}", member_str));
+    }
+
+    lines.into_iter().skip(scroll).collect()
+}
+
+pub fn draw_room_list_panel(
+    frame: &mut Frame<CrosstermBackend<impl Write>>,
+    rooms: &[Room],
+    active_id: Option<&str>,
+    scroll: usize,
+    chunk: Rect,
+) {
+    let lines: Vec<_> = build_room_lines(rooms, active_id, scroll)
+        .into_iter()
+        .map(|l| tui::text::Spans::from(Span::raw(l)))
+        .collect();
+
+    let panel = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(Span::styled("Rooms", Style::default().add_modifier(Modifier::BOLD))),
+    );
+
+    frame.render_widget(panel, chunk);
+}

--- a/src/ui/room_list_panel.rs
+++ b/src/ui/room_list_panel.rs
@@ -61,7 +61,12 @@ pub fn build_room_lines(rooms: &[Room], active_id: Option<&str>, scroll: usize) 
         lines.push(format!("  {}", member_str));
     }
 
-    lines.into_iter().skip(scroll).collect()
+    let scrolled: Vec<String> = lines.into_iter().skip(scroll).collect();
+    if scrolled.is_empty() {
+        vec!["  (no rooms)".to_string()]
+    } else {
+        scrolled
+    }
 }
 
 pub fn draw_room_list_panel(

--- a/tests/room_list_panel.rs
+++ b/tests/room_list_panel.rs
@@ -160,3 +160,21 @@ fn left_column_rooms_scales_for_tall_terminals() {
     let c = left_column_constraints(50);
     assert_eq!(c[1], Constraint::Length(50 * 2 / 5));
 }
+
+#[test]
+fn left_column_rooms_clamped_for_very_short_terminals() {
+    use tui::layout::Constraint;
+    use triadchat::ui::layout::left_column_constraints;
+    // height=4 is less than the 8-row floor — must not request more than available
+    let c = left_column_constraints(4);
+    assert_eq!(c[1], Constraint::Length(4));
+}
+
+#[test]
+fn scroll_past_content_shows_placeholder() {
+    let rooms = vec![make_room("room-1", &["alice"], None)];
+    // 1 room × 2 lines; scroll=99 is far past the end
+    let lines = build_room_lines(&rooms, None, 99);
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("no rooms"), "got: {:?}", lines[0]);
+}

--- a/tests/room_list_panel.rs
+++ b/tests/room_list_panel.rs
@@ -1,0 +1,162 @@
+use triadchat::room::{Member, Room};
+use triadchat::state::{AiMode, ScrollMovement, State};
+use triadchat::ui::room_list_panel::build_room_lines;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn make_room(id: &str, members: &[&str], ai_mode: Option<AiMode>) -> Room {
+    let mut m: Vec<Member> = members.iter().map(|&n| Member::human(n)).collect();
+    if let Some(ref mode) = ai_mode {
+        m.push(Member::ai("ops-ai", mode.clone()));
+    }
+    Room { id: id.to_string(), members: m, ai_mode }
+}
+
+fn line_text(lines: &[String], idx: usize) -> &str {
+    lines.get(idx).map(String::as_str).unwrap_or("")
+}
+
+// ─── build_room_lines ─────────────────────────────────────────────────────────
+
+#[test]
+fn empty_rooms_shows_placeholder() {
+    let lines = build_room_lines(&[], None, 0);
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("no rooms"), "got: {:?}", lines[0]);
+}
+
+#[test]
+fn active_room_has_asterisk_marker() {
+    let rooms = vec![make_room("room-1", &["alice"], Some(AiMode::Clerk))];
+    let lines = build_room_lines(&rooms, Some("room-1"), 0);
+    assert!(line_text(&lines, 0).starts_with("* "), "got: {:?}", lines[0]);
+}
+
+#[test]
+fn inactive_room_has_space_marker() {
+    let rooms = vec![make_room("room-1", &["alice"], None)];
+    let lines = build_room_lines(&rooms, Some("room-99"), 0);
+    assert!(line_text(&lines, 0).starts_with("  "), "got: {:?}", lines[0]);
+}
+
+#[test]
+fn room_id_truncated_to_8_chars() {
+    let rooms = vec![make_room("room-abcdefghij", &["alice"], None)];
+    let lines = build_room_lines(&rooms, None, 0);
+    // line 0: "  room-abc" (marker 2 + id 8 = 10, then optional mode)
+    let trimmed = line_text(&lines, 0).trim();
+    assert!(trimmed.starts_with("room-abc"), "got: {:?}", lines[0]);
+    assert!(!trimmed.contains("room-abcdefghij"), "id should be truncated");
+}
+
+#[test]
+fn ai_mode_shown_on_first_line() {
+    let rooms = vec![make_room("room-1", &["alice"], Some(AiMode::Clerk))];
+    let lines = build_room_lines(&rooms, None, 0);
+    assert!(line_text(&lines, 0).contains("clerk"), "got: {:?}", lines[0]);
+}
+
+#[test]
+fn members_shown_on_second_line() {
+    let rooms = vec![make_room("room-1", &["alice", "bob"], None)];
+    let lines = build_room_lines(&rooms, None, 0);
+    let member_line = line_text(&lines, 1);
+    assert!(member_line.contains("alice"), "got: {:?}", member_line);
+    assert!(member_line.contains("bob"), "got: {:?}", member_line);
+}
+
+#[test]
+fn member_name_truncated_to_6_chars() {
+    let rooms = vec![make_room("room-1", &["verylongname"], None)];
+    let lines = build_room_lines(&rooms, None, 0);
+    let member_line = line_text(&lines, 1);
+    assert!(member_line.contains("verylo"), "got: {:?}", member_line);
+    assert!(!member_line.contains("verylongname"), "name should be truncated");
+}
+
+#[test]
+fn ops_ai_excluded_from_member_line() {
+    let rooms = vec![make_room("room-1", &["alice"], Some(AiMode::Clerk))];
+    let lines = build_room_lines(&rooms, None, 0);
+    let member_line = line_text(&lines, 1);
+    assert!(!member_line.contains("ops-ai"), "ops-ai should not appear in member line");
+    assert!(member_line.contains("alice"), "got: {:?}", member_line);
+}
+
+#[test]
+fn multiple_rooms_render_two_lines_each() {
+    let rooms = vec![
+        make_room("room-1", &["alice"], Some(AiMode::Clerk)),
+        make_room("room-2", &["bob"], None),
+    ];
+    let lines = build_room_lines(&rooms, Some("room-1"), 0);
+    // 2 rooms × 2 lines = 4
+    assert_eq!(lines.len(), 4, "got {} lines: {:?}", lines.len(), lines);
+}
+
+#[test]
+fn scroll_offset_skips_lines() {
+    let rooms = vec![make_room("room-1", &["alice"], None), make_room("room-2", &["bob"], None)];
+    let all = build_room_lines(&rooms, None, 0);
+    let scrolled = build_room_lines(&rooms, None, 2);
+    assert_ne!(all[0], scrolled[0], "scroll should shift content");
+    assert_eq!(all[2], scrolled[0], "first line with offset=2 should be room-2 line");
+}
+
+#[test]
+fn member_line_total_truncated_to_14_chars() {
+    // 3 members with 6-char names + spaces = 6+1+6+1+6 = 20 → truncate to 14
+    let rooms = vec![make_room("room-1", &["aaaaaa", "bbbbbb", "cccccc"], None)];
+    let lines = build_room_lines(&rooms, None, 0);
+    let member_line = line_text(&lines, 1).trim_start(); // trim the "  " prefix
+    assert!(member_line.len() <= 14, "member line too long: {:?}", member_line);
+}
+
+// ─── State scroll ─────────────────────────────────────────────────────────────
+
+#[test]
+fn scroll_down_increments() {
+    let mut s = State::default();
+    s.scroll_room_list(ScrollMovement::Down);
+    assert_eq!(s.room_list_scroll(), 1);
+}
+
+#[test]
+fn scroll_up_clamps_at_zero() {
+    let mut s = State::default();
+    s.scroll_room_list(ScrollMovement::Up);
+    assert_eq!(s.room_list_scroll(), 0);
+}
+
+#[test]
+fn reset_room_list_scroll_returns_to_zero() {
+    let mut s = State::default();
+    s.scroll_room_list(ScrollMovement::Down);
+    s.scroll_room_list(ScrollMovement::Down);
+    s.reset_room_list_scroll();
+    assert_eq!(s.room_list_scroll(), 0);
+}
+
+// ─── layout constraints ───────────────────────────────────────────────────────
+
+#[test]
+fn left_column_constraints_has_two_entries() {
+    use triadchat::ui::layout::left_column_constraints;
+    assert_eq!(left_column_constraints(20).len(), 2);
+}
+
+#[test]
+fn left_column_rooms_floor_is_8_for_short_terminals() {
+    use tui::layout::Constraint;
+    use triadchat::ui::layout::left_column_constraints;
+    let c = left_column_constraints(20);
+    assert_eq!(c[1], Constraint::Length(8));
+}
+
+#[test]
+fn left_column_rooms_scales_for_tall_terminals() {
+    use tui::layout::Constraint;
+    use triadchat::ui::layout::left_column_constraints;
+    let c = left_column_constraints(50);
+    assert_eq!(c[1], Constraint::Length(50 * 2 / 5));
+}


### PR DESCRIPTION
## Summary

- Adds a scrollable **Room List** panel below the Peers panel in the left column of the TUI
- Each room renders as 2 lines: `[marker][id:8] [mode]` + `  [members ≤14 chars]`
- ops-ai is excluded from the member line; member names truncated to 6 chars each
- Alt+↑/↓ scrolls the room list independently from the chat scroll
- `left_column_constraints(height)` dynamically sizes the Rooms panel (min 8 rows, 40% at height>30, clamped for very short terminals)

## Changes

- `src/ui/room_list_panel.rs` — pure `build_room_lines()` function + `draw_room_list_panel()`
- `src/ui/layout.rs` — `left_column_constraints()` for left column vertical split
- `src/ui.rs` — splits left column, renders Peers above Rooms
- `src/state.rs` — `room_list_scroll` field + `scroll_room_list()` / `reset_room_list_scroll()`
- `src/application/mod.rs` — Alt+↑/↓ key bindings

## Test plan

- [x] 19 unit tests written first (TDD), all passing
- [x] Codex review completed; MEDIUM findings addressed (height clamping, saturating scroll, blank-panel guard)
- [x] HIGH finding (RoomCreate protocol missing ai_mode) tracked as pre-existing issue — out of scope
- [x] `cargo fmt --all` applied
- [ ] Manual E2E: launch two terminals, create rooms, verify list renders and scrolls