### PR TITLE
feat: add claude and neko avatar presets

### DIFF
--- a/src/avatar/builtin.rs
+++ b/src/avatar/builtin.rs
@@ -147,11 +147,138 @@ pub fn robot_guardian() -> Box<dyn AvatarPlugin> {
     Box::new(RobotGuardian)
 }
 
+// ─── claude ───────────────────────────────────────────────────────────────────
+
+struct ClaudeAvatar;
+
+impl AvatarPlugin for ClaudeAvatar {
+    fn preset_name(&self) -> &str {
+        "claude"
+    }
+
+    fn render(&self, state: AvatarState, size: AvatarSize) -> String {
+        match size {
+            AvatarSize::Compact => match state {
+                AvatarState::Idle | AvatarState::Online => "◈(・ω・)".into(),
+                AvatarState::Thinking => "◉(・・・)".into(),
+                AvatarState::Acting => "▶(☆ω☆)".into(),
+                AvatarState::Failed => "✕(×_×)".into(),
+                AvatarState::Disabled => "○(・ー・)".into(),
+                AvatarState::Busy => "◉(>ω<)".into(),
+                AvatarState::Away => "◈(-ω-)".into(),
+                AvatarState::Offline => "○(._.)".into(),
+            },
+            AvatarSize::Normal => match state {
+                AvatarState::Idle | AvatarState::Online => " (・ω・)\n╰[claude]╯\n  /   \\".into(),
+                AvatarState::Thinking => " (・・・)\n╰[claude]╯ ~\n  /   \\".into(),
+                AvatarState::Acting => " (☆ω☆)\n╰[claude]╯>>\n  >>  \\".into(),
+                AvatarState::Failed => " (×_×)\n╰[claude]╯\n  /   \\".into(),
+                AvatarState::Disabled => " (・ー・)\n╰[claude]╯\n  /   \\".into(),
+                AvatarState::Busy => " (>ω<)\n╰[claude]╯\n  / ! \\".into(),
+                AvatarState::Away => " (-ω-)\n╰[claude]╯\n  /   \\".into(),
+                AvatarState::Offline => " (._. )\n╰[claude]╯\n  /   \\".into(),
+            },
+            AvatarSize::Expressive => match state {
+                AvatarState::Idle | AvatarState::Online => {
+                    "╭─────╮\n│ ◕ω◕ │\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                }
+                AvatarState::Thinking => {
+                    "╭─────╮\n│ ◉ ◉ │~\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                }
+                AvatarState::Acting => {
+                    "╭─────╮\n│ ☆ω☆ │\n│claude│\n╰──┬──╯\n >>|__\n/>> \\".into()
+                }
+                AvatarState::Failed => {
+                    "╭─────╮\n│ ×_× │\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                }
+                AvatarState::Disabled => {
+                    "╭─────╮\n│ ・ー・│\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                }
+                AvatarState::Busy => {
+                    "╭─────╮\n│ >ω< │\n│claude│\n╰──┬──╯\n __|__\n/ ! \\".into()
+                }
+                AvatarState::Away => {
+                    "╭─────╮\n│ -ω- │\n│claude│\n╰──┬──╯\n __|__\nz/   \\".into()
+                }
+                AvatarState::Offline => {
+                    "╭─────╮\n│ ._. │\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                }
+            },
+        }
+    }
+}
+
+/// Returns a `Box<dyn AvatarPlugin>` for the `claude` preset.
+pub fn claude() -> Box<dyn AvatarPlugin> {
+    Box::new(ClaudeAvatar)
+}
+
+// ─── neko ─────────────────────────────────────────────────────────────────────
+
+struct NekoAvatar;
+
+impl AvatarPlugin for NekoAvatar {
+    fn preset_name(&self) -> &str {
+        "neko"
+    }
+
+    fn render(&self, state: AvatarState, size: AvatarSize) -> String {
+        match size {
+            AvatarSize::Compact => match state {
+                AvatarState::Online | AvatarState::Idle => "=^・ω・^=".into(),
+                AvatarState::Away => "=^-ω-^=".into(),
+                AvatarState::Offline => "=^x_x^=".into(),
+                AvatarState::Busy | AvatarState::Acting => "=^>ω<^=".into(),
+                AvatarState::Thinking => "=^・・・^=".into(),
+                AvatarState::Disabled => "=^・ー・^=".into(),
+                AvatarState::Failed => "=^×_×^=".into(),
+            },
+            AvatarSize::Normal => match state {
+                AvatarState::Online | AvatarState::Idle => " /\\_/\\\n( ^ω^ )\n > 🐾 <".into(),
+                AvatarState::Away => " /\\_/\\\n( -ω- )\n > zzz".into(),
+                AvatarState::Offline => " /\\_/\\\n( x_x )\n >    <".into(),
+                AvatarState::Busy | AvatarState::Acting => " /\\_/\\\n( >ω< )\n > !! <".into(),
+                AvatarState::Thinking => " /\\_/\\\n( ・・・)\n > ... <".into(),
+                AvatarState::Disabled => " /\\_/\\\n( ・ー・)\n >    <".into(),
+                AvatarState::Failed => " /\\_/\\\n( ×_× )\n > !! <".into(),
+            },
+            AvatarSize::Expressive => match state {
+                AvatarState::Online | AvatarState::Idle => {
+                    " /\\_____/\\\n/  ^   ^  \\\n\\ ( ◕ω◕ ) /\n \\  =^=  /\n  \\/   \\/\n  neko!".into()
+                }
+                AvatarState::Away => {
+                    " /\\_____/\\\n/  -   -  \\\n\\ ( -ω- ) /\n \\  =^=  /\n  \\/   \\/\n  zzzz".into()
+                }
+                AvatarState::Offline => {
+                    " /\\_____/\\\n/  x   x  \\\n\\ ( x_x ) /\n \\  =^=  /\n  \\/   \\/\n  gone".into()
+                }
+                AvatarState::Busy | AvatarState::Acting => {
+                    " /\\_____/\\\n/  >   <  \\\n\\ ( >ω< ) /\n \\  =^=  /\n  \\/   \\/\n  busy!".into()
+                }
+                AvatarState::Thinking => {
+                    " /\\_____/\\\n/  .   .  \\\n\\ (・・・) /\n \\  =^=  /\n  \\/   \\/\n  hmm...".into()
+                }
+                AvatarState::Disabled => {
+                    " /\\_____/\\\n/  -   -  \\\n\\ (・ー・) /\n \\  =^=  /\n  \\/   \\/\n  ...".into()
+                }
+                AvatarState::Failed => {
+                    " /\\_____/\\\n/  ×   ×  \\\n\\ ( ×_× ) /\n \\  =^=  /\n  \\/   \\/\n  oh no".into()
+                }
+            },
+        }
+    }
+}
+
+/// Returns a `Box<dyn AvatarPlugin>` for the `neko` preset.
+pub fn neko() -> Box<dyn AvatarPlugin> {
+    Box::new(NekoAvatar)
+}
+
 // ─── All builtin presets ─────────────────────────────────────────────────────
 
 /// Returns all builtin preset plugins.
 pub fn all_builtins() -> Vec<Box<dyn AvatarPlugin>> {
-    vec![human_default(), ai_default(), robot_guardian()]
+    vec![human_default(), ai_default(), robot_guardian(), claude(), neko()]
 }
 
 /// Render the `human_default` avatar without a heap allocation.

--- a/src/avatar/builtin.rs
+++ b/src/avatar/builtin.rs
@@ -244,25 +244,32 @@ impl AvatarPlugin for NekoAvatar {
             },
             AvatarSize::Expressive => match state {
                 AvatarState::Online | AvatarState::Idle => {
-                    " /\\_____/\\\n/  ^   ^  \\\n\\ ( ◕ω◕ ) /\n \\  =^=  /\n  \\/   \\/\n  neko!".into()
+                    " /\\_____/\\\n/  ^   ^  \\\n\\ ( ◕ω◕ ) /\n \\  =^=  /\n  \\/   \\/\n  neko!"
+                        .into()
                 }
                 AvatarState::Away => {
-                    " /\\_____/\\\n/  -   -  \\\n\\ ( -ω- ) /\n \\  =^=  /\n  \\/   \\/\n  zzzz".into()
+                    " /\\_____/\\\n/  -   -  \\\n\\ ( -ω- ) /\n \\  =^=  /\n  \\/   \\/\n  zzzz"
+                        .into()
                 }
                 AvatarState::Offline => {
-                    " /\\_____/\\\n/  x   x  \\\n\\ ( x_x ) /\n \\  =^=  /\n  \\/   \\/\n  gone".into()
+                    " /\\_____/\\\n/  x   x  \\\n\\ ( x_x ) /\n \\  =^=  /\n  \\/   \\/\n  gone"
+                        .into()
                 }
                 AvatarState::Busy | AvatarState::Acting => {
-                    " /\\_____/\\\n/  >   <  \\\n\\ ( >ω< ) /\n \\  =^=  /\n  \\/   \\/\n  busy!".into()
+                    " /\\_____/\\\n/  >   <  \\\n\\ ( >ω< ) /\n \\  =^=  /\n  \\/   \\/\n  busy!"
+                        .into()
                 }
                 AvatarState::Thinking => {
-                    " /\\_____/\\\n/  .   .  \\\n\\ (・・・) /\n \\  =^=  /\n  \\/   \\/\n  hmm...".into()
+                    " /\\_____/\\\n/  .   .  \\\n\\ (・・・) /\n \\  =^=  /\n  \\/   \\/\n  hmm..."
+                        .into()
                 }
                 AvatarState::Disabled => {
-                    " /\\_____/\\\n/  -   -  \\\n\\ (・ー・) /\n \\  =^=  /\n  \\/   \\/\n  ...".into()
+                    " /\\_____/\\\n/  -   -  \\\n\\ (・ー・) /\n \\  =^=  /\n  \\/   \\/\n  ..."
+                        .into()
                 }
                 AvatarState::Failed => {
-                    " /\\_____/\\\n/  ×   ×  \\\n\\ ( ×_× ) /\n \\  =^=  /\n  \\/   \\/\n  oh no".into()
+                    " /\\_____/\\\n/  ×   ×  \\\n\\ ( ×_× ) /\n \\  =^=  /\n  \\/   \\/\n  oh no"
+                        .into()
                 }
             },
         }

--- a/src/avatar/builtin.rs
+++ b/src/avatar/builtin.rs
@@ -180,28 +180,28 @@ impl AvatarPlugin for ClaudeAvatar {
             },
             AvatarSize::Expressive => match state {
                 AvatarState::Idle | AvatarState::Online => {
-                    "╭─────╮\n│ ◕ω◕ │\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                    "╭──────╮\n│ ◕ω◕  │\n│claude│\n╰──┬───╯\n __|__\n/     \\".into()
                 }
                 AvatarState::Thinking => {
-                    "╭─────╮\n│ ◉ ◉ │~\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                    "╭──────╮\n│ ◉ ◉  │~\n│claude│\n╰──┬───╯\n __|__\n/     \\".into()
                 }
                 AvatarState::Acting => {
-                    "╭─────╮\n│ ☆ω☆ │\n│claude│\n╰──┬──╯\n >>|__\n/>> \\".into()
+                    "╭──────╮\n│ ☆ω☆  │\n│claude│\n╰──┬───╯\n >>|__\n/>>   \\".into()
                 }
                 AvatarState::Failed => {
-                    "╭─────╮\n│ ×_× │\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                    "╭──────╮\n│ ×_×  │\n│claude│\n╰──┬───╯\n __|__\n/     \\".into()
                 }
                 AvatarState::Disabled => {
-                    "╭─────╮\n│ ・ー・│\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                    "╭──────╮\n│ ・ー・ │\n│claude│\n╰──┬───╯\n __|__\n/     \\".into()
                 }
                 AvatarState::Busy => {
-                    "╭─────╮\n│ >ω< │\n│claude│\n╰──┬──╯\n __|__\n/ ! \\".into()
+                    "╭──────╮\n│ >ω<  │\n│claude│\n╰──┬───╯\n __|__\n/ ! \\".into()
                 }
                 AvatarState::Away => {
-                    "╭─────╮\n│ -ω- │\n│claude│\n╰──┬──╯\n __|__\nz/   \\".into()
+                    "╭──────╮\n│ -ω-  │\n│claude│\n╰──┬───╯\n __|__\nz/    \\".into()
                 }
                 AvatarState::Offline => {
-                    "╭─────╮\n│ ._. │\n│claude│\n╰──┬──╯\n __|__\n/     \\".into()
+                    "╭──────╮\n│ ._.  │\n│claude│\n╰──┬───╯\n __|__\n/     \\".into()
                 }
             },
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ pub fn draw(
     theme: &Theme,
     language: &LanguageConfig,
 ) {
-    // Vertical split: upper area + input
+    // Outer vertical split: [upper(min), input(6)]
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(0), Constraint::Length(6)].as_ref())
@@ -44,18 +44,18 @@ pub fn draw(
     if should_show_side_panels(chunk.width) {
         // ── Wide layout ────────────────────────────────────────────────────
         //
-        //  ┌──────────┬───────────────┬──────────┐
-        //  │  Peers   │     Chat      │  ops-ai  │
-        //  ├──────────┤               │          │
-        //  │  Rooms   │               │          │
-        //  ├──────────┴───────────────┴──────────┤
-        //  │               Input                 │
-        //  └─────────────────────────────────────┘
+        //  ┌──────────┬──────────────────────┐
+        //  │  Peers   │        Chat          │
+        //  │──────────┤──────────────────────┤
+        //  │  Rooms   │       ops-ai         │
+        //  ├──────────┴──────────────────────┤
+        //  │              Input              │
+        //  └─────────────────────────────────┘
         //
-        // Horizontal: left column(18) | chat(min) | status(22)
+        // Horizontal: left column(18) | right column(min)
         let h_chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints(layout::three_pane_constraints())
+            .constraints(layout::left_right_constraints())
             .split(upper_chunk);
 
         // Left column: peers(min) above, rooms(scaled) below
@@ -63,6 +63,12 @@ pub fn draw(
             .direction(Direction::Vertical)
             .constraints(layout::left_column_constraints(upper_chunk.height))
             .split(h_chunks[0]);
+
+        // Right column: chat(min) above, ops-ai(11) below
+        let right_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(layout::right_column_constraints())
+            .split(h_chunks[1]);
 
         draw_peers_panel(frame, state, left_chunks[0]);
         draw_room_list_panel(
@@ -77,26 +83,33 @@ pub fn draw(
             let chat_chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Min(0), Constraint::Length(30)].as_ref())
-                .split(h_chunks[1]);
+                .split(right_chunks[0]);
             draw_messages_panel(frame, state, chat_chunks[0], theme, language);
             draw_video_panel(frame, state, chat_chunks[1]);
         } else {
-            draw_messages_panel(frame, state, h_chunks[1], theme, language);
+            draw_messages_panel(frame, state, right_chunks[0], theme, language);
         }
 
-        draw_status_panel(frame, state, h_chunks[2]);
+        draw_status_panel(frame, state, right_chunks[1]);
     } else {
-        // ── narrow fallback: chat only ──────────────────────────────────────
+        // ── Narrow layout: chat above, ops-ai below ─────────────────────────
+        let right_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(layout::right_column_constraints())
+            .split(upper_chunk);
+
         if !state.windows.is_empty() {
-            let h_chunks = Layout::default()
+            let chat_chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Min(0), Constraint::Length(30)].as_ref())
-                .split(upper_chunk);
-            draw_messages_panel(frame, state, h_chunks[0], theme, language);
-            draw_video_panel(frame, state, h_chunks[1]);
+                .split(right_chunks[0]);
+            draw_messages_panel(frame, state, chat_chunks[0], theme, language);
+            draw_video_panel(frame, state, chat_chunks[1]);
         } else {
-            draw_messages_panel(frame, state, upper_chunk, theme, language);
+            draw_messages_panel(frame, state, right_chunks[0], theme, language);
         }
+
+        draw_status_panel(frame, state, right_chunks[1]);
     }
 
     draw_input_panel(frame, state, v_chunks[1], theme);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,12 +1,19 @@
 use tui::layout::Constraint;
 
-/// Returns the 3-pane horizontal constraints: [peers(18), chat(min), status(22)].
-pub fn three_pane_constraints() -> Vec<Constraint> {
-    vec![Constraint::Length(18), Constraint::Min(0), Constraint::Length(22)]
+/// Horizontal split: [peers(18), right(min)].
+/// Peers spans the full height of the upper area (above input).
+pub fn left_right_constraints() -> Vec<Constraint> {
+    vec![Constraint::Length(18), Constraint::Min(0)]
 }
 
-/// Returns `true` when the terminal is wide enough to show side panels.
-/// Below 80 columns the layout collapses to a single chat pane.
+/// Vertical split for the right column: [chat(min), status(11)].
+/// ops-ai panel sits below chat at full right-column width.
+pub fn right_column_constraints() -> Vec<Constraint> {
+    vec![Constraint::Min(0), Constraint::Length(11)]
+}
+
+/// Returns `true` when the terminal is wide enough to show the peers side panel.
+/// Below 80 columns the layout collapses to chat-above / ops-ai-below only.
 pub fn should_show_side_panels(cols: u16) -> bool {
     cols >= 80
 }

--- a/tests/avatar_builtin.rs
+++ b/tests/avatar_builtin.rs
@@ -1,5 +1,5 @@
 use triadchat::avatar::{AvatarSize, AvatarState};
-use triadchat::avatar::builtin::{ai_default, human_default, robot_guardian};
+use triadchat::avatar::builtin::{ai_default, claude, human_default, neko, robot_guardian};
 
 // ─── AvatarSize auto-selection ────────────────────────────────────────────────
 
@@ -116,6 +116,92 @@ fn all_builtins_can_be_used_as_trait_objects() {
         let output = plugin.render(AvatarState::Idle, AvatarSize::Normal);
         assert!(!output.is_empty(), "trait object render for '{}' was empty", plugin.preset_name());
     }
+}
+
+// ─── claude ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn claude_preset_name_is_claude() {
+    assert_eq!(claude().preset_name(), "claude");
+}
+
+#[test]
+fn claude_returns_non_empty_for_all_states_and_sizes() {
+    let plugin = claude();
+    for state in all_states() {
+        for size in all_sizes() {
+            let rendered = plugin.render(state.clone(), size);
+            assert!(!rendered.is_empty(), "claude rendered empty for {state:?} {size:?}");
+        }
+    }
+}
+
+#[test]
+fn claude_compact_is_single_line_for_all_states() {
+    let plugin = claude();
+    for state in all_states() {
+        let rendered = plugin.render(state.clone(), AvatarSize::Compact);
+        assert!(!rendered.contains('\n'), "claude compact must be single-line for {state:?}");
+    }
+}
+
+#[test]
+fn claude_thinking_differs_from_idle() {
+    let plugin = claude();
+    let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
+    let thinking = plugin.render(AvatarState::Thinking, AvatarSize::Normal);
+    assert_ne!(idle, thinking);
+}
+
+#[test]
+fn claude_acting_differs_from_idle() {
+    let plugin = claude();
+    let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
+    let acting = plugin.render(AvatarState::Acting, AvatarSize::Normal);
+    assert_ne!(idle, acting);
+}
+
+// ─── neko ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn neko_preset_name_is_neko() {
+    assert_eq!(neko().preset_name(), "neko");
+}
+
+#[test]
+fn neko_returns_non_empty_for_all_states_and_sizes() {
+    let plugin = neko();
+    for state in all_states() {
+        for size in all_sizes() {
+            let rendered = plugin.render(state.clone(), size);
+            assert!(!rendered.is_empty(), "neko rendered empty for {state:?} {size:?}");
+        }
+    }
+}
+
+#[test]
+fn neko_compact_is_single_line_for_all_states() {
+    let plugin = neko();
+    for state in all_states() {
+        let rendered = plugin.render(state.clone(), AvatarSize::Compact);
+        assert!(!rendered.contains('\n'), "neko compact must be single-line for {state:?}");
+    }
+}
+
+#[test]
+fn neko_online_differs_from_offline() {
+    let plugin = neko();
+    let online = plugin.render(AvatarState::Online, AvatarSize::Normal);
+    let offline = plugin.render(AvatarState::Offline, AvatarSize::Normal);
+    assert_ne!(online, offline);
+}
+
+#[test]
+fn neko_busy_differs_from_online() {
+    let plugin = neko();
+    let online = plugin.render(AvatarState::Online, AvatarSize::Normal);
+    let busy = plugin.render(AvatarState::Busy, AvatarSize::Normal);
+    assert_ne!(online, busy);
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/tests/ui_layout.rs
+++ b/tests/ui_layout.rs
@@ -1,32 +1,47 @@
-use triadchat::ui::layout::{three_pane_constraints, should_show_side_panels};
+use triadchat::ui::layout::{left_right_constraints, right_column_constraints, should_show_side_panels};
 
-// ─── Three-pane constraint generation ────────────────────────────────────────
+// ─── Left/right horizontal constraints ───────────────────────────────────────
 
 #[test]
-fn three_pane_constraints_have_correct_widths() {
-    let constraints = three_pane_constraints();
-    assert_eq!(constraints.len(), 3, "must have exactly 3 constraints");
+fn left_right_constraints_have_two_panes() {
+    let constraints = left_right_constraints();
+    assert_eq!(constraints.len(), 2);
 }
 
 #[test]
 fn peers_panel_width_is_18() {
     use tui::layout::Constraint;
-    let constraints = three_pane_constraints();
+    let constraints = left_right_constraints();
     assert_eq!(constraints[0], Constraint::Length(18));
 }
 
 #[test]
-fn status_panel_width_is_22() {
+fn right_column_uses_min_constraint() {
     use tui::layout::Constraint;
-    let constraints = three_pane_constraints();
-    assert_eq!(constraints[2], Constraint::Length(22));
+    let constraints = left_right_constraints();
+    assert_eq!(constraints[1], Constraint::Min(0));
+}
+
+// ─── Right column vertical constraints ───────────────────────────────────────
+
+#[test]
+fn right_column_constraints_have_two_panes() {
+    let constraints = right_column_constraints();
+    assert_eq!(constraints.len(), 2);
 }
 
 #[test]
-fn chat_panel_uses_min_constraint() {
+fn chat_uses_min_constraint() {
     use tui::layout::Constraint;
-    let constraints = three_pane_constraints();
-    assert_eq!(constraints[1], Constraint::Min(0));
+    let constraints = right_column_constraints();
+    assert_eq!(constraints[0], Constraint::Min(0));
+}
+
+#[test]
+fn status_panel_height_is_11() {
+    use tui::layout::Constraint;
+    let constraints = right_column_constraints();
+    assert_eq!(constraints[1], Constraint::Length(11));
 }
 
 // ─── Side panel visibility ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `claude` preset: friendly AI avatar inspired by Claude Code's mascot style, with rounded head and expressive faces per state
- Adds `neko` preset: cute cat character with presence-reactive expressions
- Both presets cover all 9 `AvatarState` variants × 3 `AvatarSize` variants
- Updated `all_builtins()` to include new presets; exports `claude()` and `neko()` constructor functions

## Test plan
- [x] `claude_preset_name_is_claude`
- [x] `claude_returns_non_empty_for_all_states_and_sizes`
- [x] `claude_compact_is_single_line_for_all_states`
- [x] `claude_thinking_differs_from_idle`
- [x] `claude_acting_differs_from_idle`
- [x] `neko_preset_name_is_neko`
- [x] `neko_returns_non_empty_for_all_states_and_sizes`
- [x] `neko_compact_is_single_line_for_all_states`
- [x] `neko_online_differs_from_offline`
- [x] `neko_busy_differs_from_online`
- [x] Existing `compact_is_single_line` test still passes (covers new presets via `all_builtins()`)
- [x] All 61 tests pass

Closes #11