### PR TITLE
feat: add Companion mode and @ops-ai mention support

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -13,7 +13,7 @@ use crate::config::{AiConfig, LanguageConfig};
 use crate::message::AiPayload;
 
 use self::parser::parse_ai_payload;
-use self::prompt::{decisions_prompt, intervene_prompt, summary_prompt, todos_prompt};
+use self::prompt::{companion_prompt, decisions_prompt, intervene_prompt, summary_prompt, todos_prompt};
 use self::sidecar::SidecarAdapter;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -22,6 +22,7 @@ pub enum AiTask {
     Todos,
     Decisions,
     Intervene,
+    Companion,
 }
 
 #[derive(Clone)]
@@ -50,6 +51,9 @@ impl AiMediator {
             AiTask::Decisions => decisions_prompt(transcript, &self.language.ai_output),
             AiTask::Intervene => {
                 intervene_prompt(transcript, last_messages, &self.language.ai_output)
+            }
+            AiTask::Companion => {
+                companion_prompt(transcript, last_messages, &self.language.ai_output)
             }
         };
         let raw = self.sidecar.ask(&prompt).await?;

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -46,3 +46,16 @@ pub fn intervene_prompt(transcript: &str, last_messages: &[String], lang: &str) 
         last_messages.join("\n")
     )
 }
+
+pub fn companion_prompt(transcript: &str, last_messages: &[String], lang: &str) -> String {
+    format!(
+        "{}\n\
+        You are an active conversation participant, not just a clerk.\n\
+        React naturally: add relevant ideas, ask clarifying questions,\n\
+        point out interesting angles, or summarise when helpful.\n\
+        Keep responses short (1-3 sentences). Do not summarise unless asked.\n\
+        LAST_MESSAGES:\n{}\n",
+        base_prompt("companion", transcript, lang),
+        last_messages.join("\n")
+    )
+}

--- a/src/ai/trigger.rs
+++ b/src/ai/trigger.rs
@@ -26,6 +26,17 @@ impl TriggerConfig {
             AiFrequency::High => Self { cooldown: Duration::from_secs(15), human_streak_limit: 2 },
         }
     }
+
+    pub fn from_frequency_and_mode(frequency: AiFrequency, mode: AiMode) -> Self {
+        match frequency {
+            AiFrequency::Low => Self { cooldown: Duration::from_secs(45), human_streak_limit: 4 },
+            AiFrequency::Normal => match mode {
+                AiMode::Companion => Self { cooldown: Duration::from_secs(10), human_streak_limit: 6 },
+                _ => Self::default(),
+            },
+            AiFrequency::High => Self { cooldown: Duration::from_secs(15), human_streak_limit: 2 },
+        }
+    }
 }
 
 pub fn should_intervene(
@@ -40,6 +51,12 @@ pub fn should_intervene(
     if ai_thinking {
         return false;
     }
+
+    // @ops-ai mention bypasses mode and cooldown checks
+    if input.contains("@ops-ai") {
+        return true;
+    }
+
     if let Some(last_ai_at) = last_ai_at {
         if now.duration_since(last_ai_at) < config.cooldown {
             return false;
@@ -54,5 +71,72 @@ pub fn should_intervene(
         AiMode::Clerk => contains_decision_marker(input) || contains_task_marker(input),
         AiMode::Moderator => contains_ambiguity(input) || contains_contradiction(input),
         AiMode::Operator => contains_execute_request(input),
+        AiMode::Companion => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> Instant {
+        Instant::now()
+    }
+
+    #[test]
+    fn companion_always_intervenes_after_cooldown() {
+        let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
+        let past = now() - Duration::from_secs(11);
+        assert!(should_intervene("any message here", AiMode::Companion, &config, false, Some(past), 0, now()));
+    }
+
+    #[test]
+    fn companion_blocked_while_ai_thinking() {
+        let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
+        let past = now() - Duration::from_secs(11);
+        assert!(!should_intervene("any message", AiMode::Companion, &config, true, Some(past), 0, now()));
+    }
+
+    #[test]
+    fn companion_blocked_during_cooldown() {
+        let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
+        let recent = now() - Duration::from_secs(5);
+        assert!(!should_intervene("any message", AiMode::Companion, &config, false, Some(recent), 0, now()));
+    }
+
+    #[test]
+    fn companion_blocked_at_streak_limit() {
+        let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
+        let past = now() - Duration::from_secs(11);
+        assert!(!should_intervene("any message", AiMode::Companion, &config, false, Some(past), 6, now()));
+    }
+
+    #[test]
+    fn companion_config_normal_freq_has_10s_cooldown() {
+        let config = TriggerConfig::from_frequency_and_mode(AiFrequency::Normal, AiMode::Companion);
+        assert_eq!(config.cooldown, Duration::from_secs(10));
+        assert_eq!(config.human_streak_limit, 6);
+    }
+
+    #[test]
+    fn mention_bypasses_cooldown_and_mode() {
+        let config = TriggerConfig::default();
+        // Still in cooldown
+        let recent = now() - Duration::from_secs(5);
+        assert!(should_intervene("@ops-ai what do you think?", AiMode::Listener, &config, false, Some(recent), 0, now()));
+    }
+
+    #[test]
+    fn mention_blocked_while_ai_thinking() {
+        let config = TriggerConfig::default();
+        let recent = now() - Duration::from_secs(5);
+        assert!(!should_intervene("@ops-ai help me", AiMode::Listener, &config, true, Some(recent), 0, now()));
+    }
+
+    #[test]
+    fn clerk_still_requires_keywords() {
+        let config = TriggerConfig::default();
+        let past = now() - Duration::from_secs(31);
+        assert!(!should_intervene("just chatting", AiMode::Clerk, &config, false, Some(past), 0, now()));
     }
 }

--- a/src/ai/trigger.rs
+++ b/src/ai/trigger.rs
@@ -31,7 +31,9 @@ impl TriggerConfig {
         match frequency {
             AiFrequency::Low => Self { cooldown: Duration::from_secs(45), human_streak_limit: 4 },
             AiFrequency::Normal => match mode {
-                AiMode::Companion => Self { cooldown: Duration::from_secs(10), human_streak_limit: 6 },
+                AiMode::Companion => {
+                    Self { cooldown: Duration::from_secs(10), human_streak_limit: 6 }
+                }
                 _ => Self::default(),
             },
             AiFrequency::High => Self { cooldown: Duration::from_secs(15), human_streak_limit: 2 },
@@ -45,8 +47,8 @@ fn contains_ops_ai_mention(input: &str) -> bool {
     const TAG: &str = "@ops-ai";
     let mut haystack = input;
     while let Some(pos) = haystack.find(TAG) {
-        let before_ok =
-            pos == 0 || haystack[..pos].chars().last().map(|c| !c.is_alphanumeric()).unwrap_or(true);
+        let before_ok = pos == 0
+            || haystack[..pos].chars().last().map(|c| !c.is_alphanumeric()).unwrap_or(true);
         let after_start = pos + TAG.len();
         let after_ok = haystack[after_start..]
             .chars()
@@ -110,28 +112,60 @@ mod tests {
     fn companion_always_intervenes_after_cooldown() {
         let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
         let past = now() - Duration::from_secs(11);
-        assert!(should_intervene("any message here", AiMode::Companion, &config, false, Some(past), 0, now()));
+        assert!(should_intervene(
+            "any message here",
+            AiMode::Companion,
+            &config,
+            false,
+            Some(past),
+            0,
+            now()
+        ));
     }
 
     #[test]
     fn companion_blocked_while_ai_thinking() {
         let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
         let past = now() - Duration::from_secs(11);
-        assert!(!should_intervene("any message", AiMode::Companion, &config, true, Some(past), 0, now()));
+        assert!(!should_intervene(
+            "any message",
+            AiMode::Companion,
+            &config,
+            true,
+            Some(past),
+            0,
+            now()
+        ));
     }
 
     #[test]
     fn companion_blocked_during_cooldown() {
         let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
         let recent = now() - Duration::from_secs(5);
-        assert!(!should_intervene("any message", AiMode::Companion, &config, false, Some(recent), 0, now()));
+        assert!(!should_intervene(
+            "any message",
+            AiMode::Companion,
+            &config,
+            false,
+            Some(recent),
+            0,
+            now()
+        ));
     }
 
     #[test]
     fn companion_blocked_at_streak_limit() {
         let config = TriggerConfig { cooldown: Duration::from_secs(10), human_streak_limit: 6 };
         let past = now() - Duration::from_secs(11);
-        assert!(!should_intervene("any message", AiMode::Companion, &config, false, Some(past), 6, now()));
+        assert!(!should_intervene(
+            "any message",
+            AiMode::Companion,
+            &config,
+            false,
+            Some(past),
+            6,
+            now()
+        ));
     }
 
     #[test]
@@ -146,21 +180,45 @@ mod tests {
         let config = TriggerConfig::default();
         // Still in cooldown
         let recent = now() - Duration::from_secs(5);
-        assert!(should_intervene("@ops-ai what do you think?", AiMode::Listener, &config, false, Some(recent), 0, now()));
+        assert!(should_intervene(
+            "@ops-ai what do you think?",
+            AiMode::Listener,
+            &config,
+            false,
+            Some(recent),
+            0,
+            now()
+        ));
     }
 
     #[test]
     fn mention_blocked_while_ai_thinking() {
         let config = TriggerConfig::default();
         let recent = now() - Duration::from_secs(5);
-        assert!(!should_intervene("@ops-ai help me", AiMode::Listener, &config, true, Some(recent), 0, now()));
+        assert!(!should_intervene(
+            "@ops-ai help me",
+            AiMode::Listener,
+            &config,
+            true,
+            Some(recent),
+            0,
+            now()
+        ));
     }
 
     #[test]
     fn clerk_still_requires_keywords() {
         let config = TriggerConfig::default();
         let past = now() - Duration::from_secs(31);
-        assert!(!should_intervene("just chatting", AiMode::Clerk, &config, false, Some(past), 0, now()));
+        assert!(!should_intervene(
+            "just chatting",
+            AiMode::Clerk,
+            &config,
+            false,
+            Some(past),
+            0,
+            now()
+        ));
     }
 
     #[test]

--- a/src/ai/trigger.rs
+++ b/src/ai/trigger.rs
@@ -39,6 +39,28 @@ impl TriggerConfig {
     }
 }
 
+/// Returns true if `input` contains `@ops-ai` as a standalone mention,
+/// not as part of an email address or a longer token like `@ops-aix`.
+fn contains_ops_ai_mention(input: &str) -> bool {
+    const TAG: &str = "@ops-ai";
+    let mut haystack = input;
+    while let Some(pos) = haystack.find(TAG) {
+        let before_ok =
+            pos == 0 || haystack[..pos].chars().last().map(|c| !c.is_alphanumeric()).unwrap_or(true);
+        let after_start = pos + TAG.len();
+        let after_ok = haystack[after_start..]
+            .chars()
+            .next()
+            .map(|c| !c.is_alphanumeric() && c != '-')
+            .unwrap_or(true);
+        if before_ok && after_ok {
+            return true;
+        }
+        haystack = &haystack[pos + 1..];
+    }
+    false
+}
+
 pub fn should_intervene(
     input: &str,
     mode: AiMode,
@@ -52,8 +74,9 @@ pub fn should_intervene(
         return false;
     }
 
-    // @ops-ai mention bypasses mode and cooldown checks
-    if input.contains("@ops-ai") {
+    // @ops-ai mention bypasses mode and cooldown checks.
+    // Use word-boundary check to avoid false matches like foo@ops-ai.example or @ops-aix.
+    if contains_ops_ai_mention(input) {
         return true;
     }
 
@@ -138,5 +161,32 @@ mod tests {
         let config = TriggerConfig::default();
         let past = now() - Duration::from_secs(31);
         assert!(!should_intervene("just chatting", AiMode::Clerk, &config, false, Some(past), 0, now()));
+    }
+
+    #[test]
+    fn mention_does_not_trigger_on_email_address() {
+        // foo@ops-ai.example should NOT match — preceded by alphanumeric
+        assert!(!contains_ops_ai_mention("send to foo@ops-ai.example"));
+    }
+
+    #[test]
+    fn mention_does_not_trigger_on_extended_token() {
+        // @ops-aix should NOT match — followed by alphanumeric
+        assert!(!contains_ops_ai_mention("@ops-aix is a different bot"));
+    }
+
+    #[test]
+    fn mention_triggers_at_start_of_string() {
+        assert!(contains_ops_ai_mention("@ops-ai help"));
+    }
+
+    #[test]
+    fn mention_triggers_mid_sentence() {
+        assert!(contains_ops_ai_mention("hey @ops-ai what do you think?"));
+    }
+
+    #[test]
+    fn mention_triggers_at_end_of_string() {
+        assert!(contains_ops_ai_mention("question for @ops-ai"));
     }
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -415,6 +415,9 @@ impl<'a> Application<'a> {
                     self.state.add_system_error_message(format!("Unknown command: {}", input));
                     return Ok(());
                 }
+                if input.trim().is_empty() {
+                    return Ok(());
+                }
 
                 self.state.add_message(ChatMessage::new(
                     format!("{} (me)", self.config.user_name),
@@ -427,7 +430,10 @@ impl<'a> Application<'a> {
                     );
                 }
                 self.state.human_streak += 1;
-                let trigger = TriggerConfig::from_frequency(self.state.ai_frequency.clone());
+                let trigger = TriggerConfig::from_frequency_and_mode(
+                    self.state.ai_frequency.clone(),
+                    self.state.ai_mode.clone(),
+                );
                 if should_intervene(
                     &input,
                     self.state.ai_mode.clone(),
@@ -437,7 +443,12 @@ impl<'a> Application<'a> {
                     self.state.human_streak,
                     Instant::now(),
                 ) {
-                    self.spawn_ai_task(AiTask::Intervene);
+                    let task = if self.state.ai_mode == AiMode::Companion {
+                        AiTask::Companion
+                    } else {
+                        AiTask::Intervene
+                    };
+                    self.spawn_ai_task(task);
                 }
             }
             Err(error) => error.report_err(&mut self.state),
@@ -562,7 +573,7 @@ impl<'a> Application<'a> {
             AppCommand::Avatar(kind) => self.process_avatar_command(kind),
             AppCommand::Help => {
                 self.state.add_system_info_message(
-                    "/summary /todos /decisions /context /ai mode <clerk|listener|moderator|operator> /ai quiet <on|off> /ai freq <low|normal|high> /room create @user [--ai <mode>] /room list /room switch <room_id> /peers /skills /skill <name> [args] /run <proposal_id> /cancel /avatar set <target> <preset> /avatar preview /avatar mode <compact|normal|expressive> /avatar list".into(),
+                    "/summary /todos /decisions /context /ai mode <clerk|listener|moderator|operator|companion> /ai quiet <on|off> /ai freq <low|normal|high> /room create @user [--ai <mode>] /room list /room switch <room_id> /peers /skills /skill <name> [args] /run <proposal_id> /cancel /avatar set <target> <preset> /avatar preview /avatar mode <compact|normal|expressive> /avatar list".into(),
                 );
             }
         }

--- a/src/commands/ai_cmd.rs
+++ b/src/commands/ai_cmd.rs
@@ -30,7 +30,7 @@ impl Command for AiCommand {
                 Ok(ParsedCommand::App(AppCommand::SetAiFrequency(frequency)))
             }
             _ => Err(anyhow::anyhow!(
-                "usage: /ai mode <clerk|listener|moderator|operator> | /ai quiet <on|off> | /ai freq <low|normal|high>"
+                "usage: /ai mode <clerk|listener|moderator|operator|companion> | /ai quiet <on|off> | /ai freq <low|normal|high>"
             )),
         }
     }
@@ -42,7 +42,32 @@ fn parse_mode(value: &str) -> Result<AiMode> {
         "listener" => Ok(AiMode::Listener),
         "moderator" => Ok(AiMode::Moderator),
         "operator" => Ok(AiMode::Operator),
+        "companion" => Ok(AiMode::Companion),
         other => Err(anyhow::anyhow!("unknown ai mode: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mode_companion_returns_companion() {
+        assert_eq!(parse_mode("companion").unwrap(), AiMode::Companion);
+    }
+
+    #[test]
+    fn parse_mode_unknown_returns_error() {
+        assert!(parse_mode("unknown_mode").is_err());
+    }
+
+    #[test]
+    fn parse_mode_all_known_modes() {
+        assert!(parse_mode("clerk").is_ok());
+        assert!(parse_mode("listener").is_ok());
+        assert!(parse_mode("moderator").is_ok());
+        assert!(parse_mode("operator").is_ok());
+        assert!(parse_mode("companion").is_ok());
     }
 }
 

--- a/src/commands/ai_cmd.rs
+++ b/src/commands/ai_cmd.rs
@@ -47,6 +47,15 @@ fn parse_mode(value: &str) -> Result<AiMode> {
     }
 }
 
+fn parse_frequency(value: &str) -> Result<AiFrequency> {
+    match value {
+        "low" => Ok(AiFrequency::Low),
+        "normal" => Ok(AiFrequency::Normal),
+        "high" => Ok(AiFrequency::High),
+        other => Err(anyhow::anyhow!("unknown ai frequency: {other}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,14 +77,5 @@ mod tests {
         assert!(parse_mode("moderator").is_ok());
         assert!(parse_mode("operator").is_ok());
         assert!(parse_mode("companion").is_ok());
-    }
-}
-
-fn parse_frequency(value: &str) -> Result<AiFrequency> {
-    match value {
-        "low" => Ok(AiFrequency::Low),
-        "normal" => Ok(AiFrequency::Normal),
-        "high" => Ok(AiFrequency::High),
-        other => Err(anyhow::anyhow!("unknown ai frequency: {other}")),
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -35,6 +35,7 @@ pub enum AiMode {
     Listener,
     Moderator,
     Operator,
+    Companion,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ pub fn draw(
     theme: &Theme,
     language: &LanguageConfig,
 ) {
-    // Vertical split: upper area + input
+    // Outer vertical split: [upper(min), input(6)]
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(0), Constraint::Length(6)].as_ref())
@@ -44,18 +44,18 @@ pub fn draw(
     if should_show_side_panels(chunk.width) {
         // ── Wide layout ────────────────────────────────────────────────────
         //
-        //  ┌──────────┬───────────────┬──────────┐
-        //  │  Peers   │     Chat      │  ops-ai  │
-        //  ├──────────┤               │          │
-        //  │  Rooms   │               │          │
-        //  ├──────────┴───────────────┴──────────┤
-        //  │               Input                 │
-        //  └─────────────────────────────────────┘
+        //  ┌──────────┬──────────────────────┐
+        //  │  Peers   │        Chat          │
+        //  │──────────┤──────────────────────┤
+        //  │  Rooms   │       ops-ai         │
+        //  ├──────────┴──────────────────────┤
+        //  │              Input              │
+        //  └─────────────────────────────────┘
         //
-        // Horizontal: left column(18) | chat(min) | status(22)
+        // Horizontal: left column(18) | right column(min)
         let h_chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints(layout::three_pane_constraints())
+            .constraints(layout::left_right_constraints())
             .split(upper_chunk);
 
         // Left column: peers(min) above, rooms(scaled) below
@@ -63,6 +63,12 @@ pub fn draw(
             .direction(Direction::Vertical)
             .constraints(layout::left_column_constraints(upper_chunk.height))
             .split(h_chunks[0]);
+
+        // Right column: chat(min) above, ops-ai(11) below
+        let right_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(layout::right_column_constraints())
+            .split(h_chunks[1]);
 
         draw_peers_panel(frame, state, left_chunks[0]);
         draw_room_list_panel(
@@ -77,26 +83,33 @@ pub fn draw(
             let chat_chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Min(0), Constraint::Length(30)].as_ref())
-                .split(h_chunks[1]);
+                .split(right_chunks[0]);
             draw_messages_panel(frame, state, chat_chunks[0], theme, language);
             draw_video_panel(frame, state, chat_chunks[1]);
         } else {
-            draw_messages_panel(frame, state, h_chunks[1], theme, language);
+            draw_messages_panel(frame, state, right_chunks[0], theme, language);
         }
 
-        draw_status_panel(frame, state, h_chunks[2]);
+        draw_status_panel(frame, state, right_chunks[1]);
     } else {
-        // ── narrow fallback: chat only ──────────────────────────────────────
+        // ── Narrow layout: chat above, ops-ai below ─────────────────────────
+        let right_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(layout::right_column_constraints())
+            .split(upper_chunk);
+
         if !state.windows.is_empty() {
-            let h_chunks = Layout::default()
+            let chat_chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Min(0), Constraint::Length(30)].as_ref())
-                .split(upper_chunk);
-            draw_messages_panel(frame, state, h_chunks[0], theme, language);
-            draw_video_panel(frame, state, h_chunks[1]);
+                .split(right_chunks[0]);
+            draw_messages_panel(frame, state, chat_chunks[0], theme, language);
+            draw_video_panel(frame, state, chat_chunks[1]);
         } else {
-            draw_messages_panel(frame, state, upper_chunk, theme, language);
+            draw_messages_panel(frame, state, right_chunks[0], theme, language);
         }
+
+        draw_status_panel(frame, state, right_chunks[1]);
     }
 
     draw_input_panel(frame, state, v_chunks[1], theme);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,12 +1,19 @@
 use tui::layout::Constraint;
 
-/// Returns the 3-pane horizontal constraints: [peers(18), chat(min), status(22)].
-pub fn three_pane_constraints() -> Vec<Constraint> {
-    vec![Constraint::Length(18), Constraint::Min(0), Constraint::Length(22)]
+/// Horizontal split: [peers(18), right(min)].
+/// Peers spans the full height of the upper area (above input).
+pub fn left_right_constraints() -> Vec<Constraint> {
+    vec![Constraint::Length(18), Constraint::Min(0)]
 }
 
-/// Returns `true` when the terminal is wide enough to show side panels.
-/// Below 80 columns the layout collapses to a single chat pane.
+/// Vertical split for the right column: [chat(min), status(11)].
+/// ops-ai panel sits below chat at full right-column width.
+pub fn right_column_constraints() -> Vec<Constraint> {
+    vec![Constraint::Min(0), Constraint::Length(11)]
+}
+
+/// Returns `true` when the terminal is wide enough to show the peers side panel.
+/// Below 80 columns the layout collapses to chat-above / ops-ai-below only.
 pub fn should_show_side_panels(cols: u16) -> bool {
     cols >= 80
 }

--- a/src/ui/status_panel.rs
+++ b/src/ui/status_panel.rs
@@ -109,6 +109,7 @@ fn format_ai_mode(mode: &AiMode) -> &'static str {
         AiMode::Listener => "listener",
         AiMode::Moderator => "moderator",
         AiMode::Operator => "operator",
+        AiMode::Companion => "companion 🗣",
     }
 }
 

--- a/tests/ui_layout.rs
+++ b/tests/ui_layout.rs
@@ -1,32 +1,47 @@
-use triadchat::ui::layout::{three_pane_constraints, should_show_side_panels};
+use triadchat::ui::layout::{left_right_constraints, right_column_constraints, should_show_side_panels};
 
-// ─── Three-pane constraint generation ────────────────────────────────────────
+// ─── Left/right horizontal constraints ───────────────────────────────────────
 
 #[test]
-fn three_pane_constraints_have_correct_widths() {
-    let constraints = three_pane_constraints();
-    assert_eq!(constraints.len(), 3, "must have exactly 3 constraints");
+fn left_right_constraints_have_two_panes() {
+    let constraints = left_right_constraints();
+    assert_eq!(constraints.len(), 2);
 }
 
 #[test]
 fn peers_panel_width_is_18() {
     use tui::layout::Constraint;
-    let constraints = three_pane_constraints();
+    let constraints = left_right_constraints();
     assert_eq!(constraints[0], Constraint::Length(18));
 }
 
 #[test]
-fn status_panel_width_is_22() {
+fn right_column_uses_min_constraint() {
     use tui::layout::Constraint;
-    let constraints = three_pane_constraints();
-    assert_eq!(constraints[2], Constraint::Length(22));
+    let constraints = left_right_constraints();
+    assert_eq!(constraints[1], Constraint::Min(0));
+}
+
+// ─── Right column vertical constraints ───────────────────────────────────────
+
+#[test]
+fn right_column_constraints_have_two_panes() {
+    let constraints = right_column_constraints();
+    assert_eq!(constraints.len(), 2);
 }
 
 #[test]
-fn chat_panel_uses_min_constraint() {
+fn chat_uses_min_constraint() {
     use tui::layout::Constraint;
-    let constraints = three_pane_constraints();
-    assert_eq!(constraints[1], Constraint::Min(0));
+    let constraints = right_column_constraints();
+    assert_eq!(constraints[0], Constraint::Min(0));
+}
+
+#[test]
+fn status_panel_height_is_11() {
+    use tui::layout::Constraint;
+    let constraints = right_column_constraints();
+    assert_eq!(constraints[1], Constraint::Length(11));
 }
 
 // ─── Side panel visibility ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `AiMode::Companion`: AI intervenes on any message (after 10s cooldown, streak limit 6), without requiring keyword triggers
- Adds `@ops-ai` mention support: bypasses mode and cooldown checks for immediate AI response (still blocked when `ai_thinking`)
- Adds `companion_prompt()` with system instruction for natural conversation participation
- Adds `AiTask::Companion` routed through `AiMediator::request()`
- `/ai mode companion` accepted by command parser
- Status panel displays `companion 🗣` when companion mode is active
- `TriggerConfig::from_frequency_and_mode()` added for mode-aware config (existing `from_frequency()` preserved)

## Mode behaviour table
| Mode | @ops-ai mention | Auto-intervene |
|------|----------------|----------------|
| clerk | ✓ immediate | keyword only |
| companion | ✓ immediate | any message |
| listener | ✓ immediate | never |
| operator | ✓ immediate | skill execution only |

## Test plan
- [x] `companion_always_intervenes_after_cooldown`
- [x] `companion_blocked_while_ai_thinking`
- [x] `companion_blocked_during_cooldown`
- [x] `companion_blocked_at_streak_limit`
- [x] `companion_config_normal_freq_has_10s_cooldown`
- [x] `mention_bypasses_cooldown_and_mode`
- [x] `mention_blocked_while_ai_thinking`
- [x] `clerk_still_requires_keywords`
- [x] `parse_mode_companion_returns_companion`
- [x] `parse_mode_unknown_returns_error`
- [x] `parse_mode_all_known_modes`
- [x] All tests pass

Closes #12