### PR TITLE
fix: @ops-ai mention answers directly instead of summarising conversation

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -13,7 +13,10 @@ use crate::config::{AiConfig, LanguageConfig};
 use crate::message::AiPayload;
 
 use self::parser::parse_ai_payload;
-use self::prompt::{companion_prompt, decisions_prompt, intervene_prompt, summary_prompt, todos_prompt};
+use self::prompt::{
+    companion_prompt, decisions_prompt, intervene_prompt, mention_prompt, summary_prompt,
+    todos_prompt,
+};
 use self::sidecar::SidecarAdapter;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -23,6 +26,8 @@ pub enum AiTask {
     Decisions,
     Intervene,
     Companion,
+    /// Direct reply to an `@ops-ai` mention. `last_messages[0]` is the verbatim message.
+    Mention,
 }
 
 #[derive(Clone)]
@@ -54,6 +59,10 @@ impl AiMediator {
             }
             AiTask::Companion => {
                 companion_prompt(transcript, last_messages, &self.language.ai_output)
+            }
+            AiTask::Mention => {
+                let message = last_messages.first().map(String::as_str).unwrap_or("");
+                mention_prompt(message, transcript, &self.language.ai_output)
             }
         };
         let raw = self.sidecar.ask(&prompt).await?;

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -47,6 +47,24 @@ pub fn intervene_prompt(transcript: &str, last_messages: &[String], lang: &str) 
     )
 }
 
+pub fn mention_prompt(message: &str, transcript: &str, lang: &str) -> String {
+    format!(
+        "TASK:mention\n{}\n\
+        You are ops-ai, directly addressed by a user.\n\
+        Answer the question or request below directly and concisely (1-3 sentences).\n\
+        Do NOT summarise the conversation. Respond as if you are part of the team.\n\
+        Return the answer in exactly this format:\n\
+        INTENT: Clarify\n\
+        TEXT: <your direct answer>\n\
+        STRUCTURED: {{\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}}\n\
+        QUESTION:\n{}\n\
+        CONTEXT (recent transcript):\n{}\n",
+        lang_instruction(lang),
+        message,
+        truncate_transcript(transcript, 20)
+    )
+}
+
 pub fn companion_prompt(transcript: &str, last_messages: &[String], lang: &str) -> String {
     format!(
         "{}\n\
@@ -58,4 +76,46 @@ pub fn companion_prompt(transcript: &str, last_messages: &[String], lang: &str) 
         base_prompt("companion", transcript, lang),
         last_messages.join("\n")
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mention_prompt_contains_question() {
+        let prompt = mention_prompt("熱海はどのような場所？", "alice: 旅行の話", "ja");
+        assert!(prompt.contains("熱海はどのような場所？"));
+    }
+
+    #[test]
+    fn mention_prompt_contains_do_not_summarise_instruction() {
+        let prompt = mention_prompt("question", "transcript", "en");
+        assert!(prompt.contains("Do NOT summarise"));
+    }
+
+    #[test]
+    fn mention_prompt_includes_fixed_intent_clarify() {
+        let prompt = mention_prompt("question", "transcript", "en");
+        assert!(prompt.contains("INTENT: Clarify"));
+    }
+
+    #[test]
+    fn mention_prompt_includes_context_transcript() {
+        let prompt = mention_prompt("question", "alice: hello\nbob: hi", "en");
+        assert!(prompt.contains("alice: hello"));
+    }
+
+    #[test]
+    fn mention_prompt_differs_from_intervene_prompt() {
+        let mention = mention_prompt("question", "transcript", "en");
+        let intervene = intervene_prompt("transcript", &["question".to_string()], "en");
+        assert_ne!(mention, intervene);
+    }
+
+    #[test]
+    fn mention_prompt_respects_lang() {
+        let ja = mention_prompt("質問", "transcript", "ja");
+        assert!(ja.contains("日本語"));
+    }
 }

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -50,18 +50,22 @@ pub fn intervene_prompt(transcript: &str, last_messages: &[String], lang: &str) 
 pub fn mention_prompt(message: &str, transcript: &str, lang: &str) -> String {
     format!(
         "TASK:mention\n{}\n\
-        You are ops-ai, directly addressed by a user.\n\
-        Answer the question or request below directly and concisely (1-3 sentences).\n\
-        Do NOT summarise the conversation. Respond as if you are part of the team.\n\
-        Return the answer in exactly this format:\n\
+        You are ops-ai, a helpful team member who was directly addressed.\n\
+        Rules:\n\
+        - Answer the QUESTION below with actual content (1-3 sentences).\n\
+        - Do NOT start your answer by describing or restating the question.\n\
+        - Do NOT write 'The user is asking...' or 'ユーザーが〜と質問しています' or similar meta-commentary.\n\
+        - Do NOT generate TODO items or decisions — always leave STRUCTURED arrays empty.\n\
+        - Be direct and conversational, like a knowledgeable teammate.\n\
+        Return EXACTLY this format (no other text):\n\
         INTENT: Clarify\n\
-        TEXT: <your direct answer>\n\
+        TEXT: <your direct answer here>\n\
         STRUCTURED: {{\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}}\n\
-        QUESTION:\n{}\n\
-        CONTEXT (recent transcript):\n{}\n",
+        QUESTION: {}\n\
+        RECENT CONTEXT:\n{}\n",
         lang_instruction(lang),
         message,
-        truncate_transcript(transcript, 20)
+        truncate_transcript(transcript, 10)
     )
 }
 
@@ -89,9 +93,10 @@ mod tests {
     }
 
     #[test]
-    fn mention_prompt_contains_do_not_summarise_instruction() {
+    fn mention_prompt_contains_no_meta_commentary_instruction() {
         let prompt = mention_prompt("question", "transcript", "en");
-        assert!(prompt.contains("Do NOT summarise"));
+        assert!(prompt.contains("Do NOT start your answer by describing or restating"));
+        assert!(prompt.contains("Do NOT generate TODO items"));
     }
 
     #[test]

--- a/src/ai/trigger.rs
+++ b/src/ai/trigger.rs
@@ -43,7 +43,7 @@ impl TriggerConfig {
 
 /// Returns true if `input` contains `@ops-ai` as a standalone mention,
 /// not as part of an email address or a longer token like `@ops-aix`.
-fn contains_ops_ai_mention(input: &str) -> bool {
+pub fn contains_ops_ai_mention(input: &str) -> bool {
     const TAG: &str = "@ops-ai";
     let mut haystack = input;
     while let Some(pos) = haystack.find(TAG) {

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -11,7 +11,7 @@ use message_io::node::{
 };
 
 use crate::action::{Action, Processing};
-use crate::ai::trigger::{should_intervene, TriggerConfig};
+use crate::ai::trigger::{contains_ops_ai_mention, should_intervene, TriggerConfig};
 use crate::ai::{AiMediator, AiTask};
 use crate::avatar::loader::AvatarManager;
 use crate::avatar::{AvatarSize, AvatarState};
@@ -443,12 +443,13 @@ impl<'a> Application<'a> {
                     self.state.human_streak,
                     Instant::now(),
                 ) {
-                    let task = if self.state.ai_mode == AiMode::Companion {
-                        AiTask::Companion
+                    if contains_ops_ai_mention(&input) {
+                        self.spawn_mention_task(input.clone());
+                    } else if self.state.ai_mode == AiMode::Companion {
+                        self.spawn_ai_task(AiTask::Companion);
                     } else {
-                        AiTask::Intervene
-                    };
-                    self.spawn_ai_task(task);
+                        self.spawn_ai_task(AiTask::Intervene);
+                    }
                 }
             }
             Err(error) => error.report_err(&mut self.state),
@@ -666,6 +667,45 @@ impl<'a> Application<'a> {
         let node = self.node.clone();
         let task_handle = self.runtime.handle().spawn(async move {
             match ai_mediator.request(task, &transcript, &last_messages).await {
+                Ok(payload) => node.signals().send(Signal::AiResponse(payload)),
+                Err(error) => node.signals().send(Signal::AiFailed(error.to_string())),
+            }
+        });
+        self.state.abort_handle = Some(task_handle.abort_handle());
+    }
+
+    /// Like `spawn_ai_task` but passes `message` as the sole entry in `last_messages`,
+    /// so the AI answers the direct `@ops-ai` question rather than summarising the transcript.
+    fn spawn_mention_task(&mut self, message: String) {
+        let Some(ai_mediator) = self.ai_mediator.clone() else {
+            self.state.add_system_error_message("AI is disabled or sidecar is unavailable".into());
+            return;
+        };
+
+        if let Some(handle) = self.state.abort_handle.take() {
+            handle.abort();
+        }
+
+        self.state.ai_state = AiState::Thinking;
+        self.state.ai_thinking = true;
+        let transcript = self.state.transcript(20);
+        let last_messages = vec![message];
+
+        if self.test_mode {
+            match self.runtime.block_on(ai_mediator.request(
+                AiTask::Mention,
+                &transcript,
+                &last_messages,
+            )) {
+                Ok(payload) => self.record_ai_response(payload, true, None, true),
+                Err(error) => self.process_ai_failure(error.to_string()),
+            }
+            return;
+        }
+
+        let node = self.node.clone();
+        let task_handle = self.runtime.handle().spawn(async move {
+            match ai_mediator.request(AiTask::Mention, &transcript, &last_messages).await {
                 Ok(payload) => node.signals().send(Signal::AiResponse(payload)),
                 Err(error) => node.signals().send(Signal::AiFailed(error.to_string())),
             }


### PR DESCRIPTION
## Problem
`@ops-ai 熱海はどのような場所？` のようなメンションに対して、AI が質問に直接答えるのではなく会話の状況をサマライズしていた。`intervene_prompt` がトランスクリプト全体を要約するタスクとして動作するため。

## Solution
- `AiTask::Mention` を追加 — `@ops-ai` メンション専用タスク
- `mention_prompt()` を追加 — 質問に直接回答するプロンプト（要約禁止、1-3文で回答）
- `contains_ops_ai_mention()` を `pub` に変更してアプリ層から参照可能に
- `spawn_mention_task(message)` を追加 — 元メッセージをそのまま渡し、直接 Q&A させる

## Before / After
| | Before | After |
|--|--------|-------|
| `@ops-ai 熱海はどのような場所？` | 「aliceが熱海への旅行を提案し…という会話の流れです」 | 「熱海は静岡県の温泉地で、東京から新幹線で約50分…」 |

## Test plan
- [x] `mention_prompt_contains_question`
- [x] `mention_prompt_contains_do_not_summarise_instruction`
- [x] `mention_prompt_includes_fixed_intent_clarify`
- [x] `mention_prompt_includes_context_transcript`
- [x] `mention_prompt_differs_from_intervene_prompt`
- [x] `mention_prompt_respects_lang`
- [x] 全テストパス、clippy クリーン