### PR TITLE
fix: improve /help output readability

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -573,9 +573,7 @@ impl<'a> Application<'a> {
             AppCommand::Cancel => self.cancel_active_task(),
             AppCommand::Avatar(kind) => self.process_avatar_command(kind),
             AppCommand::Help => {
-                self.state.add_system_info_message(
-                    "/summary /todos /decisions /context /ai mode <clerk|listener|moderator|operator|companion> /ai quiet <on|off> /ai freq <low|normal|high> /room create @user [--ai <mode>] /room list /room switch <room_id> /peers /skills /skill <name> [args] /run <proposal_id> /cancel /avatar set <target> <preset> /avatar preview /avatar mode <compact|normal|expressive> /avatar list".into(),
-                );
+                self.state.add_system_info_message(help_text());
             }
         }
     }
@@ -1002,6 +1000,43 @@ impl<'a> Application<'a> {
             let _ = std::fs::write(path, serialized);
         }
     }
+}
+
+fn help_text() -> String {
+    [
+        "AI",
+        "/ai mode <clerk|listener|moderator|operator|companion>  Change AI behaviour mode",
+        "/ai quiet <on|off>                                     Mute/unmute AI responses",
+        "/ai freq <low|normal|high>                             Adjust AI intervention frequency",
+        "",
+        "Summary",
+        "/summary   Summarise the conversation",
+        "/todos     List action items",
+        "/decisions List decisions made",
+        "/context   Summarise context",
+        "",
+        "Rooms",
+        "/room create @user [--ai <mode>]  Create a room with peers",
+        "/room list                        List all rooms",
+        "/room switch <room_id>            Switch active room",
+        "/peers                            List connected peers",
+        "",
+        "Skills",
+        "/skills               List available skills",
+        "/skill <name> [args]  Run a skill",
+        "/run <proposal_id>    Accept a skill proposal",
+        "/cancel               Cancel pending skill",
+        "",
+        "Avatar",
+        "/avatar set <target> <preset>             Set avatar preset",
+        "/avatar preview                           Preview your avatar",
+        "/avatar mode <compact|normal|expressive>  Set avatar size",
+        "/avatar list                              List available presets",
+        "",
+        "Files",
+        "/send <file>  Send a file to peers",
+    ]
+    .join("\n")
 }
 
 impl Drop for Application<'_> {

--- a/tests/phase0_commands_e2e.rs
+++ b/tests/phase0_commands_e2e.rs
@@ -130,3 +130,39 @@ fn slash_commands_are_not_included_in_transcript() {
     assert!(transcript.contains("auth serviceに切り出したい"));
     assert!(!transcript.contains("/summary"));
 }
+
+#[test]
+fn help_command_groups_commands_with_descriptions() {
+    let mut config = Config::default();
+    config.ai.enabled = false;
+    let mut app = Application::new_for_test(&config).unwrap();
+
+    app.handle_input_line_for_test("/help").unwrap();
+
+    let rendered = app
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("AI"));
+    assert!(rendered.contains("Summary"));
+    assert!(rendered.contains("Rooms"));
+    assert!(rendered.contains("Skills"));
+    assert!(rendered.contains("Avatar"));
+    assert!(rendered.contains("Files"));
+    assert!(rendered.contains("Change AI behaviour mode"));
+    assert!(rendered.contains("Summarise the conversation"));
+    assert!(rendered.contains("Create a room with peers"));
+    assert!(rendered.contains("Set avatar preset"));
+    assert!(rendered.contains("Send a file to peers"));
+    assert!(rendered.contains("/ai mode <clerk|listener|moderator|operator|companion>"));
+    assert!(rendered.contains("/room switch <room_id>"));
+    assert!(rendered.contains("Switch active room"));
+    assert!(rendered.contains("/skill <name> [args]"));
+    assert!(rendered.contains("Run a skill"));
+    assert!(rendered.contains("/send <file>"));
+    assert!(rendered.contains('\n'));
+}


### PR DESCRIPTION
Closes #5.

## Summary
- group `/help` commands by category
- add short descriptions for each command
- cover the output with a command E2E test