### PR TITLE
fix: improve AI command UX feedback

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -31,7 +31,8 @@ use crate::room::transcript::TranscriptEntry;
 use crate::room::{MemberKind, Room};
 use crate::renderer::Renderer;
 use crate::state::{
-    AiMode, AiState, ChatMessage, CursorMovement, MessageType, ScrollMovement, State, Window,
+    AiFrequency, AiMode, AiState, ChatMessage, CursorMovement, MessageType, ScrollMovement, State,
+    Window,
 };
 use crate::skill::executor::{PendingSkillExecution, SkillExecutor};
 use crate::skill::registry::{InvokeMode, RiskLevel};
@@ -426,7 +427,10 @@ impl<'a> Application<'a> {
             Ok(Some(ParsedCommand::App(command))) => self.process_app_command(command),
             Ok(None) => {
                 if input.starts_with(CommandManager::COMMAND_PREFIX) {
-                    self.state.add_system_error_message(format!("Unknown command: {}", input));
+                    self.state.add_system_error_message(format!(
+                        "Unknown command '{}'. Type /help for available commands.",
+                        input
+                    ));
                     return Ok(());
                 }
                 if input.trim().is_empty() {
@@ -483,8 +487,10 @@ impl<'a> Application<'a> {
             },
             AppCommand::SetAiMode(mode) => {
                 self.state.ai_mode = mode;
-                self.state
-                    .add_system_info_message(format!("AI mode set to {:?}", self.state.ai_mode));
+                self.state.add_system_info_message(format!(
+                    "AI mode set to {}",
+                    ai_mode_label(&self.state.ai_mode)
+                ));
             }
             AppCommand::SetAiQuiet(enabled) => {
                 self.state.ai_mode = if enabled { AiMode::Listener } else { AiMode::Clerk };
@@ -497,8 +503,8 @@ impl<'a> Application<'a> {
             AppCommand::SetAiFrequency(frequency) => {
                 self.state.ai_frequency = frequency;
                 self.state.add_system_info_message(format!(
-                    "AI frequency set to {:?}",
-                    self.state.ai_frequency
+                    "AI frequency set to {}",
+                    ai_frequency_label(&self.state.ai_frequency)
                 ));
             }
             AppCommand::RoomCreate { peers, ai_mode } => {
@@ -1083,7 +1089,10 @@ impl<'a> Application<'a> {
 
     fn resolve_room_switch_target(&self, target: &str) -> Option<String> {
         if let Ok(index) = target.parse::<usize>() {
-            return self.state.rooms().get(index.saturating_sub(1)).map(|room| room.id.clone());
+            return index
+                .checked_sub(1)
+                .and_then(|idx| self.state.rooms().get(idx))
+                .map(|room| room.id.clone());
         }
         self.state.rooms().iter().find(|room| room.id == target).map(|room| room.id.clone())
     }
@@ -1113,16 +1122,6 @@ fn human_member_names(room: &Room) -> Vec<String> {
         .filter(|member| member.kind == MemberKind::Human)
         .map(|member| member.id.clone())
         .collect()
-}
-
-fn ai_mode_label(mode: &AiMode) -> &'static str {
-    match mode {
-        AiMode::Clerk => "clerk",
-        AiMode::Listener => "listener",
-        AiMode::Moderator => "moderator",
-        AiMode::Operator => "operator",
-        AiMode::Companion => "companion",
-    }
 }
 
 fn help_text() -> String {
@@ -1168,6 +1167,24 @@ impl Drop for Application<'_> {
             handle.abort();
         }
         self.node.stop();
+    }
+}
+
+fn ai_mode_label(mode: &AiMode) -> &'static str {
+    match mode {
+        AiMode::Clerk => "clerk",
+        AiMode::Listener => "listener",
+        AiMode::Moderator => "moderator",
+        AiMode::Operator => "operator",
+        AiMode::Companion => "companion",
+    }
+}
+
+fn ai_frequency_label(frequency: &AiFrequency) -> &'static str {
+    match frequency {
+        AiFrequency::Low => "low",
+        AiFrequency::Normal => "normal",
+        AiFrequency::High => "high",
     }
 }
 

--- a/src/commands/ai_cmd.rs
+++ b/src/commands/ai_cmd.rs
@@ -30,7 +30,7 @@ impl Command for AiCommand {
                 Ok(ParsedCommand::App(AppCommand::SetAiFrequency(frequency)))
             }
             _ => Err(anyhow::anyhow!(
-                "usage: /ai mode <clerk|listener|moderator|operator|companion> | /ai quiet <on|off> | /ai freq <low|normal|high>"
+                "usage: /ai mode <mode>\n  clerk      - responds to decisions and task markers\n  listener   - silent; never auto-intervenes\n  moderator  - intervenes on ambiguous or contradictory messages\n  operator   - responds to execute, deploy, or run requests\n  companion  - chats actively and replies to direct prompts\nusage: /ai quiet <on|off>\nusage: /ai freq <low|normal|high>"
             )),
         }
     }
@@ -59,6 +59,7 @@ fn parse_frequency(value: &str) -> Result<AiFrequency> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::Command;
 
     #[test]
     fn parse_mode_companion_returns_companion() {
@@ -77,5 +78,19 @@ mod tests {
         assert!(parse_mode("moderator").is_ok());
         assert!(parse_mode("operator").is_ok());
         assert!(parse_mode("companion").is_ok());
+    }
+
+    #[test]
+    fn parse_params_error_describes_available_modes() {
+        let error = AiCommand
+            .parse_params(vec!["wat".into()])
+            .err()
+            .expect("invalid subcommand should error");
+
+        assert!(error.to_string().contains("usage: /ai mode <mode>"));
+        assert!(error.to_string().contains("clerk"));
+        assert!(error.to_string().contains("listener"));
+        assert!(error.to_string().contains("moderator"));
+        assert!(error.to_string().contains("operator"));
     }
 }

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -137,3 +137,40 @@ fn room_and_peer_commands_show_richer_metadata() {
     assert!(rendered.contains("Switched to room-1 [takuro, tanaka]"), "{rendered}");
     assert!(rendered.contains("AI: clerk"), "{rendered}");
 }
+
+#[test]
+fn room_switch_rejects_zero_index() {
+    let discovery_port = 40000 + (rand::random::<u16>() % 1000);
+    let takuro_config = test_config("takuro", discovery_port);
+    let tanaka_config = test_config("tanaka", discovery_port);
+    let mut takuro = Application::new_for_test(&takuro_config).unwrap();
+    let mut tanaka = Application::new_for_test(&tanaka_config).unwrap();
+
+    takuro.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    tanaka.start_network_for_test().unwrap();
+    takuro.announce_presence_for_test().unwrap();
+    tanaka.announce_presence_for_test().unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().peers().len() == 1 && right.state().peers().len() == 1
+    });
+
+    takuro.handle_input_line_for_test("/room create @tanaka --ai clerk").unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().rooms().len() == 1
+            && right.state().rooms().len() == 1
+            && left.state().active_room_id() == right.state().active_room_id()
+    });
+
+    let active_room =
+        takuro.state().active_room_id().expect("active room should exist").to_string();
+    takuro.handle_input_line_for_test("/room switch 0").unwrap();
+
+    let rendered =
+        takuro.state().messages().last().expect("switch error should be rendered").rendered_text();
+
+    assert_eq!(rendered, "unknown room id: 0");
+    assert_eq!(takuro.state().active_room_id(), Some(active_room.as_str()));
+}

--- a/tests/phase0_commands_e2e.rs
+++ b/tests/phase0_commands_e2e.rs
@@ -168,6 +168,40 @@ fn help_command_groups_commands_with_descriptions() {
 }
 
 #[test]
+fn ai_commands_report_human_readable_feedback() {
+    let mut config = Config::default();
+    config.ai.enabled = false;
+    let mut app = Application::new_for_test(&config).unwrap();
+
+    app.handle_input_line_for_test("/ai mode moderator").unwrap();
+    app.handle_input_line_for_test("/ai freq low").unwrap();
+
+    let rendered = app
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("AI mode set to moderator"));
+    assert!(rendered.contains("AI frequency set to low"));
+}
+
+#[test]
+fn unknown_command_points_users_to_help() {
+    let mut config = Config::default();
+    config.ai.enabled = false;
+    let mut app = Application::new_for_test(&config).unwrap();
+
+    app.handle_input_line_for_test("/does-not-exist").unwrap();
+
+    let rendered = app.state().messages().last().expect("unknown command message").rendered_text();
+
+    assert_eq!(rendered, "Unknown command '/does-not-exist'. Type /help for available commands.");
+}
+
+#[test]
 fn room_create_unknown_peer_points_to_peers_command() {
     let mut config = Config::default();
     config.ai.enabled = false;

--- a/tests/sidecar_mock.rs
+++ b/tests/sidecar_mock.rs
@@ -30,10 +30,13 @@ async fn sidecar_returns_stdout() {
         "mock-claude.sh",
         "#!/bin/sh\ncat <<'EOF'\nINTENT: Summary\nTEXT: mock summary\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\nEOF\n",
     );
-    let adapter = SidecarAdapter::from_command(dir.path(), script, Duration::from_secs(1))
+    let adapter = SidecarAdapter::from_command(dir.path(), "/bin/sh", Duration::from_secs(1))
         .expect("adapter should be created");
 
-    let output = adapter.ask("hello").await.expect("sidecar should succeed");
+    let output = adapter
+        .ask(script.to_str().expect("script path should be utf-8"))
+        .await
+        .expect("sidecar should succeed");
     assert!(output.contains("mock summary"));
 }
 
@@ -41,10 +44,13 @@ async fn sidecar_returns_stdout() {
 async fn sidecar_times_out() {
     let dir = TempDir::new().unwrap();
     let script = write_script(&dir, "slow-claude.sh", "#!/bin/sh\nsleep 2\nprintf 'late'\n");
-    let adapter = SidecarAdapter::from_command(dir.path(), script, Duration::from_millis(100))
+    let adapter = SidecarAdapter::from_command(dir.path(), "/bin/sh", Duration::from_millis(100))
         .expect("adapter should be created");
 
-    let error = adapter.ask("hello").await.expect_err("sidecar should time out");
+    let error = adapter
+        .ask(script.to_str().expect("script path should be utf-8"))
+        .await
+        .expect_err("sidecar should time out");
     assert!(error.to_string().contains("timed out"));
 }
 


### PR DESCRIPTION
Closes #8.

## Summary
- switch AI mode/frequency feedback to lowercase human-readable labels
- expand `/ai` usage text with mode descriptions
- point unknown commands to `/help`
- add command-level regression tests