### PR TITLE
feat: support multiple AI providers in sidecar

### DIFF
--- a/src/ai/sidecar.rs
+++ b/src/ai/sidecar.rs
@@ -4,12 +4,13 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 use tokio::process::Command;
 
-use crate::config::AiConfig;
+use crate::config::{AiConfig, AiProvider};
 
 #[derive(Clone, Debug)]
 pub struct SidecarAdapter {
     workspace: PathBuf,
     command: PathBuf,
+    prefix_args: Vec<String>,
     timeout: Duration,
 }
 
@@ -18,10 +19,13 @@ impl SidecarAdapter {
         let timeout = Duration::from_secs(config.timeout_secs.max(1));
         let command = if let Some(command) = &config.command {
             resolve_command(command)?
+        } else if let Some(default_command) = config.provider.default_command() {
+            which::which(default_command)
+                .with_context(|| format!("{default_command} command was not found in PATH"))?
         } else {
-            which::which("claude").context("claude command was not found in PATH")?
+            bail!("ai provider 'custom' requires ai.command to be set");
         };
-        Self::from_command(workspace, command, timeout)
+        Self::from_command_with_provider(workspace, command, config.provider.clone(), timeout)
     }
 
     pub fn from_command(
@@ -29,11 +33,25 @@ impl SidecarAdapter {
         command: impl Into<PathBuf>,
         timeout: Duration,
     ) -> Result<Self> {
+        Self::from_command_with_provider(workspace, command, AiProvider::Claude, timeout)
+    }
+
+    fn from_command_with_provider(
+        workspace: &Path,
+        command: impl Into<PathBuf>,
+        provider: AiProvider,
+        timeout: Duration,
+    ) -> Result<Self> {
         let command = command.into();
         if !command.exists() {
             bail!("sidecar command does not exist: {}", command.display());
         }
-        Ok(Self { workspace: workspace.to_path_buf(), command, timeout })
+        Ok(Self {
+            workspace: workspace.to_path_buf(),
+            command,
+            prefix_args: provider.prefix_args().iter().map(|arg| (*arg).to_string()).collect(),
+            timeout,
+        })
     }
 
     pub async fn ask(&self, prompt: &str) -> Result<String> {
@@ -50,8 +68,8 @@ impl SidecarAdapter {
         let output = tokio::time::timeout(timeout, async {
             Command::new(&self.command)
                 .current_dir(&self.workspace)
-                .arg("-p")
-                .arg(prompt)
+                .args(&self.prefix_args)
+                .arg(&prompt)
                 .output()
                 .await
         })
@@ -82,4 +100,70 @@ fn resolve_command(command: &str) -> Result<PathBuf> {
         return Ok(path);
     }
     which::which(command).with_context(|| format!("{command} command was not found in PATH"))
+}
+
+impl AiProvider {
+    pub fn default_command(&self) -> Option<&'static str> {
+        let (command, _) = self.invocation();
+        (!command.is_empty()).then_some(command)
+    }
+
+    pub fn prefix_args(&self) -> &'static [&'static str] {
+        let (_, prefix_args) = self.invocation();
+        prefix_args
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_script(dir: &TempDir, name: &str) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, "#!/bin/sh\nprintf 'ok\\n'\n").unwrap();
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+
+    #[test]
+    fn provider_prefix_args_match_invocation() {
+        for provider in
+            [AiProvider::Claude, AiProvider::Codex, AiProvider::Gemini, AiProvider::Custom]
+        {
+            let (_, prefix_args) = provider.invocation();
+            assert_eq!(provider.prefix_args(), prefix_args);
+        }
+    }
+
+    #[test]
+    fn new_uses_provider_specific_prefix_args() {
+        let dir = TempDir::new().unwrap();
+        let script = write_script(&dir, "mock-ai.sh");
+        let config = AiConfig {
+            enabled: true,
+            provider: AiProvider::Codex,
+            command: Some(script.display().to_string()),
+            timeout_secs: 1,
+        };
+
+        let adapter = SidecarAdapter::new(dir.path(), &config).unwrap();
+        assert_eq!(adapter.prefix_args, vec!["exec".to_string()]);
+    }
+
+    #[test]
+    fn from_command_defaults_to_claude_prefix_args() {
+        let dir = TempDir::new().unwrap();
+        let script = write_script(&dir, "mock-ai.sh");
+
+        let adapter =
+            SidecarAdapter::from_command(dir.path(), script, Duration::from_secs(1)).unwrap();
+        assert_eq!(adapter.prefix_args, vec!["-p".to_string()]);
+    }
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -122,6 +122,7 @@ impl<'a> Application<'a> {
         state.ui_language = config.language.ui.clone();
         state.user_avatar = config.user.avatar.clone();
         state.ai_avatar = config.user.ai_avatar.clone();
+        state.ai_provider = config.ai.provider.clone();
         state.set_trusted_peer_fingerprints(config.security.trusted_peers.clone());
         state.set_skill_registry(crate::skill::registry::SkillRegistry::scan(workspace));
         state.set_transcript_base_dir(dirs_next::data_dir());

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,15 +117,70 @@ impl Default for UserConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AiProvider {
+    Claude,
+    Codex,
+    Gemini,
+    Custom,
+}
+
+impl Default for AiProvider {
+    fn default() -> Self {
+        Self::Claude
+    }
+}
+
+impl AiProvider {
+    pub fn invocation(&self) -> (&'static str, &'static [&'static str]) {
+        match self {
+            Self::Claude => ("claude", &["-p"]),
+            Self::Codex => ("codex", &["exec"]),
+            Self::Gemini => ("gemini", &["-p"]),
+            Self::Custom => ("", &[]),
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Gemini => "gemini",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AiConfig {
     pub enabled: bool,
+    #[serde(default)]
+    pub provider: AiProvider,
     pub command: Option<String>,
     pub timeout_secs: u64,
 }
 
 impl Default for AiConfig {
     fn default() -> Self {
-        Self { enabled: true, command: None, timeout_secs: 30 }
+        Self { enabled: true, provider: AiProvider::Claude, command: None, timeout_secs: 30 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AiConfig, AiProvider};
+
+    #[test]
+    fn provider_invocation_matches_supported_clis() {
+        assert_eq!(AiProvider::Claude.invocation(), ("claude", &["-p"][..]));
+        assert_eq!(AiProvider::Codex.invocation(), ("codex", &["exec"][..]));
+        assert_eq!(AiProvider::Gemini.invocation(), ("gemini", &["-p"][..]));
+        assert_eq!(AiProvider::Custom.invocation(), ("", &[][..]));
+    }
+
+    #[test]
+    fn ai_config_defaults_to_claude_provider() {
+        assert_eq!(AiConfig::default().provider, AiProvider::Claude);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,19 +116,14 @@ impl Default for UserConfig {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AiProvider {
+    #[default]
     Claude,
     Codex,
     Gemini,
     Custom,
-}
-
-impl Default for AiProvider {
-    fn default() -> Self {
-        Self::Claude
-    }
 }
 
 impl AiProvider {

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 use tokio::task::AbortHandle;
 
 use crate::avatar::AvatarSize;
+use crate::config::AiProvider;
 use crate::message::{AiPayload, PeerInfo, StructuredOutput};
 use crate::room::transcript::{TranscriptEntry, TranscriptWriter};
 use crate::room::{Room, RoomEngine};
@@ -126,6 +127,7 @@ pub struct State {
     pub stop_stream: bool,
     pub windows: HashMap<Endpoint, Window>,
     pub ai_state: AiState,
+    pub ai_provider: AiProvider,
     pub ai_mode: AiMode,
     pub ai_thinking: bool,
     pub abort_handle: Option<AbortHandle>,
@@ -164,6 +166,7 @@ impl Default for State {
             stop_stream: false,
             windows: HashMap::new(),
             ai_state: AiState::Idle,
+            ai_provider: AiProvider::Claude,
             ai_mode: AiMode::Clerk,
             ai_thinking: false,
             abort_handle: None,

--- a/src/ui/status_panel.rs
+++ b/src/ui/status_panel.rs
@@ -1,32 +1,24 @@
-use tui::backend::CrosstermBackend;
+use tui::backend::Backend;
 use tui::layout::Rect;
 use tui::style::{Color, Modifier, Style};
 use tui::text::{Span, Spans};
 use tui::widgets::{Block, Borders, Paragraph};
 use tui::Frame;
 
-use std::io::Write;
-
 use crate::avatar::builtin::render_ai;
 use crate::avatar::{AvatarSize, AvatarState};
+use crate::config::AiProvider;
 use crate::state::{AiMode, AiState, SkillProposal, State};
 use crate::ui::layout::truncate;
 
-/// Draws the right status panel (22-column side panel).
-///
-/// Shows AI avatar (normal size), current mode/state, last 5 TODO items, and
-/// pending skill proposals.
-pub fn draw_status_panel(
-    frame: &mut Frame<CrosstermBackend<impl Write>>,
-    state: &State,
-    chunk: Rect,
-) {
+/// Draws the ops-ai status panel below chat.
+pub fn draw_status_panel(frame: &mut Frame<impl Backend>, state: &State, chunk: Rect) {
+    let inner_width = chunk.width.saturating_sub(2);
     let avatar_state = ai_state_to_avatar_state(&state.ai_state);
     let av_art = render_ai(avatar_state, AvatarSize::Normal);
 
     let mut lines: Vec<Spans> = Vec::new();
 
-    // AI avatar
     for line in av_art.lines() {
         lines.push(Spans::from(Span::styled(
             line.to_string(),
@@ -34,26 +26,24 @@ pub fn draw_status_panel(
         )));
     }
 
-    lines.push(Spans::from(Span::raw("")));
-
-    // Mode line
     lines.push(Spans::from(vec![
         Span::styled("Mode: ", Style::default().fg(Color::Gray)),
         Span::styled(
-            format_ai_mode(&state.ai_mode),
+            format!(
+                "{} [{}]",
+                format_ai_mode(&state.ai_mode),
+                format_ai_provider(&state.ai_provider)
+            ),
             Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled("State: ", Style::default().fg(Color::Gray)),
+        Span::styled(
+            format_ai_state_with_width(&state.ai_state, inner_width),
+            ai_state_color(&state.ai_state),
         ),
     ]));
 
-    // State line
-    lines.push(Spans::from(vec![
-        Span::styled("State: ", Style::default().fg(Color::Gray)),
-        Span::styled(format_ai_state(&state.ai_state), ai_state_color(&state.ai_state)),
-    ]));
-
-    lines.push(Spans::from(Span::raw("")));
-
-    // Skill proposals
     let proposals = state.skill_proposals();
     if !proposals.is_empty() {
         lines.push(Spans::from(Span::styled(
@@ -61,12 +51,17 @@ pub fn draw_status_panel(
             Style::default().fg(Color::Gray).add_modifier(Modifier::BOLD),
         )));
         for proposal in proposals.iter().take(3) {
-            lines.push(proposal_span(proposal));
+            lines.push(proposal_span(proposal, inner_width));
         }
-        lines.push(Spans::from(Span::raw("")));
+        if let Some(overflow) = overflow_line(proposals.len().saturating_sub(3)) {
+            lines.push(Spans::from(Span::styled(overflow, Style::default().fg(Color::DarkGray))));
+        }
+        lines.push(Spans::from(Span::styled(
+            "✓ trusted  ? unverified",
+            Style::default().fg(Color::DarkGray),
+        )));
     }
 
-    // Last 5 TODOs from structured output
     if let Some(structured) = &state.last_structured_output {
         if !structured.todos.is_empty() {
             lines.push(Spans::from(Span::styled(
@@ -76,9 +71,16 @@ pub fn draw_status_panel(
             for todo in structured.todos.iter().take(5) {
                 let assignee =
                     todo.assignee.as_deref().map(|a| format!("[{}] ", a)).unwrap_or_default();
-                let text = format!("• {}{}", assignee, truncate(&todo.text, 16));
+                let text =
+                    format!("• {}{}", assignee, truncate(&todo.text, todo_text_limit(inner_width)));
                 lines
                     .push(Spans::from(Span::styled(text, Style::default().fg(Color::LightYellow))));
+            }
+            if let Some(overflow) = overflow_line(structured.todos.len().saturating_sub(5)) {
+                lines.push(Spans::from(Span::styled(
+                    overflow,
+                    Style::default().fg(Color::DarkGray),
+                )));
             }
         }
     }
@@ -90,8 +92,6 @@ pub fn draw_status_panel(
     );
     frame.render_widget(panel, chunk);
 }
-
-// ─── helpers ─────────────────────────────────────────────────────────────────
 
 fn ai_state_to_avatar_state(ai_state: &AiState) -> AvatarState {
     match ai_state {
@@ -113,13 +113,19 @@ fn format_ai_mode(mode: &AiMode) -> &'static str {
     }
 }
 
-fn format_ai_state(state: &AiState) -> String {
+fn format_ai_provider(provider: &AiProvider) -> &'static str {
+    provider.label()
+}
+
+fn format_ai_state_with_width(state: &AiState, width: u16) -> String {
     match state {
         AiState::Idle => "idle".into(),
         AiState::Thinking => "thinking…".into(),
         AiState::Acting => "acting".into(),
         AiState::Disabled => "disabled".into(),
-        AiState::Failed(reason) => format!("failed: {}", truncate(reason, 10)),
+        AiState::Failed(reason) => {
+            format!("failed: {}", truncate(reason, failure_reason_limit(width)))
+        }
     }
 }
 
@@ -133,9 +139,152 @@ fn ai_state_color(state: &AiState) -> Style {
     }
 }
 
-fn proposal_span(proposal: &SkillProposal) -> Spans<'static> {
+fn proposal_span(proposal: &SkillProposal, width: u16) -> Spans<'static> {
     let trusted_marker = if proposal.trusted { "✓" } else { "?" };
-    let text =
-        format!("[{}] {} {}", proposal.id, trusted_marker, truncate(&proposal.skill_name, 12));
+    let text = format!(
+        "[{}] {} {}",
+        proposal.id,
+        trusted_marker,
+        truncate(&proposal.skill_name, proposal_name_limit(width))
+    );
     Spans::from(Span::styled(text, Style::default().fg(Color::LightBlue)))
+}
+
+fn todo_text_limit(width: u16) -> usize {
+    width.saturating_sub(20).clamp(16, 40) as usize
+}
+
+fn failure_reason_limit(width: u16) -> usize {
+    width.saturating_sub(30).clamp(10, 30) as usize
+}
+
+fn proposal_name_limit(width: u16) -> usize {
+    width.saturating_sub(40).clamp(12, 20) as usize
+}
+
+fn overflow_line(hidden_count: usize) -> Option<String> {
+    (hidden_count > 0).then(|| format!("  … +{hidden_count} more"))
+}
+
+#[cfg(test)]
+mod tests {
+    use tui::backend::TestBackend;
+    use tui::Terminal;
+
+    use super::*;
+    use crate::message::{StructuredOutput, TodoItem};
+    use crate::state::State;
+
+    #[test]
+    fn wide_panel_uses_roomier_text_limits() {
+        assert_eq!(todo_text_limit(60), 40);
+        assert_eq!(failure_reason_limit(60), 30);
+        assert_eq!(proposal_name_limit(60), 20);
+    }
+
+    #[test]
+    fn narrow_panel_keeps_minimum_text_limits() {
+        assert!(todo_text_limit(20) >= 16);
+        assert!(failure_reason_limit(20) >= 10);
+        assert!(proposal_name_limit(20) >= 12);
+    }
+
+    #[test]
+    fn failed_state_uses_width_aware_truncation() {
+        let state = AiState::Failed("Connection refused by sidecar".into());
+        let rendered = format_ai_state_with_width(&state, 60);
+
+        assert!(rendered.contains("Connection refused by sidecar"));
+    }
+
+    #[test]
+    fn overflow_line_is_hidden_when_nothing_overflows() {
+        assert_eq!(overflow_line(0), None);
+    }
+
+    #[test]
+    fn overflow_line_reports_hidden_count() {
+        assert_eq!(overflow_line(3).as_deref(), Some("  … +3 more"));
+    }
+
+    #[test]
+    fn rendered_panel_includes_provider_and_wider_text() {
+        let mut state = State::default();
+        state.ai_mode = AiMode::Clerk;
+        state.ai_provider = AiProvider::Gemini;
+        state.ai_state = AiState::Failed("Connection refused by upstream sidecar".into());
+        state.set_skill_proposals(&["email_processor".into()], Some("alice".into()), true);
+        state.last_structured_output = Some(StructuredOutput {
+            todos: vec![TodoItem {
+                text: "Implement auth module with provider switching".into(),
+                assignee: Some("takuro".into()),
+            }],
+            decisions: Vec::new(),
+            skill_suggestions: Vec::new(),
+            raw_text: None,
+        });
+
+        let backend = TestBackend::new(72, 11);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.size();
+                draw_status_panel(frame, &state, area);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let rendered = (0..11)
+            .map(|y| {
+                (0..72)
+                    .map(|x| buffer.get(x, y).symbol.clone())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Mode: clerk [gemini]"));
+        assert!(rendered.contains("Connection refused"));
+        assert!(rendered.contains("email_processor"));
+        assert!(rendered.contains("Implement auth module"));
+        assert!(rendered.contains("✓ trusted"));
+    }
+
+    #[test]
+    fn rendered_panel_reports_proposal_overflow() {
+        let mut state = State::default();
+        state.ai_mode = AiMode::Operator;
+        state.ai_provider = AiProvider::Claude;
+        state.ai_state = AiState::Idle;
+        state.set_skill_proposals(
+            &["first".into(), "second".into(), "third".into(), "fourth".into()],
+            None,
+            true,
+        );
+
+        let backend = TestBackend::new(72, 11);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.size();
+                draw_status_panel(frame, &state, area);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let rendered = (0..11)
+            .map(|y| {
+                (0..72)
+                    .map(|x| buffer.get(x, y).symbol.clone())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("… +1 more"));
+    }
 }

--- a/tests/sidecar_mock.rs
+++ b/tests/sidecar_mock.rs
@@ -1,11 +1,12 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use tempfile::TempDir;
 
 use triadchat::ai::sidecar::SidecarAdapter;
-use triadchat::config::AiConfig;
+use triadchat::config::{AiConfig, AiProvider};
 
 fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
     let path = dir.path().join(name);
@@ -16,13 +17,19 @@ fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
     path
 }
 
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|error| error.into_inner())
+}
+
 #[tokio::test]
 async fn sidecar_returns_stdout() {
+    let _guard = env_lock();
     let dir = TempDir::new().unwrap();
     let script = write_script(
         &dir,
         "mock-claude.sh",
-        "#!/bin/sh\nprintf 'INTENT: Summary\nTEXT: mock summary\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\n'",
+        "#!/bin/sh\ncat <<'EOF'\nINTENT: Summary\nTEXT: mock summary\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\nEOF\n",
     );
     let adapter = SidecarAdapter::from_command(dir.path(), script, Duration::from_secs(1))
         .expect("adapter should be created");
@@ -33,6 +40,7 @@ async fn sidecar_returns_stdout() {
 
 #[tokio::test]
 async fn sidecar_times_out() {
+    let _guard = env_lock();
     let dir = TempDir::new().unwrap();
     let script = write_script(&dir, "slow-claude.sh", "#!/bin/sh\nsleep 2\nprintf 'late'\n");
     let adapter = SidecarAdapter::from_command(dir.path(), script, Duration::from_millis(100))
@@ -44,11 +52,12 @@ async fn sidecar_times_out() {
 
 #[test]
 fn configured_sidecar_command_can_be_resolved_from_path() {
+    let _guard = env_lock();
     let dir = TempDir::new().unwrap();
     write_script(
         &dir,
         "mock-claude.sh",
-        "#!/bin/sh\nprintf 'INTENT: Summary\nTEXT: mock summary\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\n'",
+        "#!/bin/sh\ncat <<'EOF'\nINTENT: Summary\nTEXT: mock summary\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\nEOF\n",
     );
 
     let original_path = std::env::var_os("PATH");
@@ -59,8 +68,12 @@ fn configured_sidecar_command_can_be_resolved_from_path() {
     }
     std::env::set_var("PATH", &new_path);
 
-    let config =
-        AiConfig { enabled: true, command: Some("mock-claude.sh".into()), timeout_secs: 1 };
+    let config = AiConfig {
+        enabled: true,
+        provider: AiProvider::Claude,
+        command: Some("mock-claude.sh".into()),
+        timeout_secs: 1,
+    };
     let adapter = SidecarAdapter::new(dir.path(), &config);
 
     if let Some(path) = original_path {
@@ -70,4 +83,66 @@ fn configured_sidecar_command_can_be_resolved_from_path() {
     }
 
     assert!(adapter.is_ok());
+}
+
+#[test]
+fn ai_config_without_provider_defaults_to_claude() {
+    let _guard = env_lock();
+    let config: AiConfig =
+        toml::from_str("enabled = true\ntimeout_secs = 30").expect("config should parse");
+
+    assert_eq!(config.provider, AiProvider::Claude);
+}
+
+#[test]
+fn custom_provider_requires_command() {
+    let _guard = env_lock();
+    let dir = TempDir::new().unwrap();
+    let config =
+        AiConfig { enabled: true, provider: AiProvider::Custom, command: None, timeout_secs: 1 };
+
+    let error = SidecarAdapter::new(dir.path(), &config).expect_err("custom without command fails");
+    assert!(error.to_string().contains("requires"));
+}
+
+fn capture_args_script(dir: &TempDir) -> std::path::PathBuf {
+    write_script(
+        dir,
+        "capture.sh",
+        "#!/bin/sh\nprintf '%s\n' \"$@\" > \"$CAPTURE_ARGS_FILE\"\nprintf 'ok'\n",
+    )
+}
+
+#[tokio::test]
+async fn provider_invocation_uses_provider_specific_args() {
+    let _guard = env_lock();
+    let dir = TempDir::new().unwrap();
+    let script = capture_args_script(&dir);
+    let args_file = dir.path().join("args.txt");
+
+    let cases = [
+        (AiProvider::Claude, vec!["-p", "hello world"]),
+        (AiProvider::Codex, vec!["exec", "hello world"]),
+        (AiProvider::Gemini, vec!["-p", "hello world"]),
+    ];
+
+    for (provider, expected_args) in cases {
+        std::env::set_var("CAPTURE_ARGS_FILE", &args_file);
+        let config = AiConfig {
+            enabled: true,
+            provider,
+            command: Some(script.display().to_string()),
+            timeout_secs: 1,
+        };
+        let adapter = SidecarAdapter::new(dir.path(), &config).expect("adapter should build");
+
+        let output = adapter.ask("hello world").await.expect("ask should succeed");
+        assert_eq!(output, "ok");
+
+        let captured = fs::read_to_string(&args_file).expect("args should be captured");
+        let captured_args = captured.lines().collect::<Vec<_>>();
+        assert_eq!(captured_args, expected_args);
+    }
+
+    std::env::remove_var("CAPTURE_ARGS_FILE");
 }

--- a/tests/sidecar_mock.rs
+++ b/tests/sidecar_mock.rs
@@ -24,7 +24,6 @@ fn env_lock() -> std::sync::MutexGuard<'static, ()> {
 
 #[tokio::test]
 async fn sidecar_returns_stdout() {
-    let _guard = env_lock();
     let dir = TempDir::new().unwrap();
     let script = write_script(
         &dir,
@@ -40,7 +39,6 @@ async fn sidecar_returns_stdout() {
 
 #[tokio::test]
 async fn sidecar_times_out() {
-    let _guard = env_lock();
     let dir = TempDir::new().unwrap();
     let script = write_script(&dir, "slow-claude.sh", "#!/bin/sh\nsleep 2\nprintf 'late'\n");
     let adapter = SidecarAdapter::from_command(dir.path(), script, Duration::from_millis(100))
@@ -87,7 +85,6 @@ fn configured_sidecar_command_can_be_resolved_from_path() {
 
 #[test]
 fn ai_config_without_provider_defaults_to_claude() {
-    let _guard = env_lock();
     let config: AiConfig =
         toml::from_str("enabled = true\ntimeout_secs = 30").expect("config should parse");
 
@@ -96,7 +93,6 @@ fn ai_config_without_provider_defaults_to_claude() {
 
 #[test]
 fn custom_provider_requires_command() {
-    let _guard = env_lock();
     let dir = TempDir::new().unwrap();
     let config =
         AiConfig { enabled: true, provider: AiProvider::Custom, command: None, timeout_secs: 1 };
@@ -105,20 +101,19 @@ fn custom_provider_requires_command() {
     assert!(error.to_string().contains("requires"));
 }
 
-fn capture_args_script(dir: &TempDir) -> std::path::PathBuf {
+fn capture_args_script(dir: &TempDir, args_file: &std::path::Path) -> std::path::PathBuf {
     write_script(
         dir,
         "capture.sh",
-        "#!/bin/sh\nprintf '%s\n' \"$@\" > \"$CAPTURE_ARGS_FILE\"\nprintf 'ok'\n",
+        &format!("#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\nprintf 'ok'\n", args_file.display()),
     )
 }
 
 #[tokio::test]
 async fn provider_invocation_uses_provider_specific_args() {
-    let _guard = env_lock();
     let dir = TempDir::new().unwrap();
-    let script = capture_args_script(&dir);
     let args_file = dir.path().join("args.txt");
+    let script = capture_args_script(&dir, &args_file);
 
     let cases = [
         (AiProvider::Claude, vec!["-p", "hello world"]),
@@ -127,7 +122,6 @@ async fn provider_invocation_uses_provider_specific_args() {
     ];
 
     for (provider, expected_args) in cases {
-        std::env::set_var("CAPTURE_ARGS_FILE", &args_file);
         let config = AiConfig {
             enabled: true,
             provider,
@@ -143,6 +137,4 @@ async fn provider_invocation_uses_provider_specific_args() {
         let captured_args = captured.lines().collect::<Vec<_>>();
         assert_eq!(captured_args, expected_args);
     }
-
-    std::env::remove_var("CAPTURE_ARGS_FILE");
 }


### PR DESCRIPTION
Closes #7.
Closes #13.

## Summary
- add `AiProvider` config support for claude/codex/gemini/custom
- build sidecar invocation args from provider selection
- show provider and wider metadata in the status panel
- extend sidecar and status-panel regression coverage