### PR TITLE
fix: improve skill execution UX

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -536,7 +536,9 @@ impl<'a> Application<'a> {
             }
             AppCommand::Skills => {
                 if self.state.skill_registry().skills().is_empty() {
-                    self.state.add_system_info_message("no skills found".into());
+                    self.state.add_system_info_message(
+                        "No skills found. Add skill scripts to .claude/skills/".into(),
+                    );
                 } else {
                     let mut skills = self
                         .state
@@ -544,13 +546,25 @@ impl<'a> Application<'a> {
                         .skills()
                         .iter()
                         .map(|skill| {
+                            let args = skill
+                                .args_hint
+                                .as_deref()
+                                .map(|hint| format!("  args: {hint}"))
+                                .unwrap_or_default();
                             format!(
-                                "{} | {:?} | {:?} | {}",
-                                skill.name, skill.risk, skill.invoke_mode, skill.description
+                                "{:<20} {:<8} {:<12} {}{}",
+                                skill.name, skill.risk, skill.invoke_mode, skill.description, args
                             )
                         })
                         .collect::<Vec<_>>();
-                    skills.insert(0, "name | risk | mode | description".into());
+                    skills.insert(
+                        0,
+                        format!("{:<20} {:<8} {:<12} {}", "name", "risk", "mode", "description"),
+                    );
+                    skills.insert(
+                        1,
+                        "------------------------------------------------------------".into(),
+                    );
                     self.state.add_system_info_message(skills.join("\n"));
                 }
             }
@@ -901,7 +915,7 @@ impl<'a> Application<'a> {
         match meta.invoke_mode {
             InvokeMode::Suggest => {
                 self.state.add_system_info_message(format!(
-                    "skill '{}' is suggest-only and cannot be executed directly",
+                    "Skill '{}' is propose-only: the AI suggests it when relevant,\nbut it cannot be run manually with /skill. Wait for a proposal in the\nstatus panel and use /run <id> to accept.",
                     meta.name
                 ));
             }

--- a/src/skill/executor.rs
+++ b/src/skill/executor.rs
@@ -31,9 +31,41 @@ impl SkillExecutor {
             },
             Err(_) => SkillResultPayload {
                 skill_name: meta.name.clone(),
-                summary: "skill timed out after 60s".into(),
+                summary: timeout_summary(meta),
                 success: false,
             },
         }
+    }
+}
+
+fn timeout_summary(meta: &SkillMeta) -> String {
+    format!(
+        "Skill '{}' timed out after 60s. Check that the skill script is executable and not hanging.",
+        meta.name
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::timeout_summary;
+    use crate::skill::registry::{InvokeMode, RiskLevel, SkillMeta, SkillScope};
+    use std::path::PathBuf;
+
+    #[test]
+    fn timeout_summary_includes_guidance() {
+        let meta = SkillMeta {
+            name: "review-auth".into(),
+            scope: SkillScope::Workspace,
+            invoke_mode: InvokeMode::Confirm,
+            allowed_tools: Vec::new(),
+            risk: RiskLevel::Medium,
+            description: "Review auth".into(),
+            args_hint: None,
+            path: PathBuf::from("SKILL.md"),
+        };
+
+        let summary = timeout_summary(&meta);
+        assert!(summary.contains("Skill 'review-auth' timed out after 60s"));
+        assert!(summary.contains("not hanging"));
     }
 }

--- a/src/skill/registry.rs
+++ b/src/skill/registry.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -23,6 +24,23 @@ pub enum InvokeMode {
     Suggest,
 }
 
+impl InvokeMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::Confirm => "confirm",
+            Self::AutoSafe => "auto-safe",
+            Self::Suggest => "suggest",
+        }
+    }
+}
+
+impl fmt::Display for InvokeMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RiskLevel {
@@ -30,6 +48,22 @@ pub enum RiskLevel {
     #[default]
     Medium,
     High,
+}
+
+impl RiskLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+impl fmt::Display for RiskLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -40,6 +74,7 @@ pub struct SkillMeta {
     pub allowed_tools: Vec<String>,
     pub risk: RiskLevel,
     pub description: String,
+    pub args_hint: Option<String>,
     pub path: PathBuf,
 }
 
@@ -117,6 +152,7 @@ impl SkillRegistry {
                 allowed_tools: parsed.allowed_tools.unwrap_or_default(),
                 risk: parsed.risk.unwrap_or_default(),
                 description,
+                args_hint: parsed.args_hint.filter(|hint| !hint.trim().is_empty()),
                 path: skill_path.clone(),
             });
         }
@@ -152,6 +188,8 @@ struct Frontmatter {
     risk: Option<RiskLevel>,
     #[serde(default)]
     description: String,
+    #[serde(default, rename = "args_hint", alias = "args-hint")]
+    args_hint: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/tests/phase1_commands_e2e.rs
+++ b/tests/phase1_commands_e2e.rs
@@ -28,6 +28,7 @@ invoke: confirm
 risk: medium
 allowed-tools: [Read, Grep]
 description: 認証ロジックをレビューする
+args_hint: <ticket-id>
 ---
 "#,
     )
@@ -73,7 +74,14 @@ fn phase1_skill_commands_execute_without_polluting_transcript() {
         .map(|message| message.rendered_text())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(rendered.contains("name | risk | mode | description"));
+    assert!(rendered.contains("name"));
+    assert!(rendered.contains("risk"));
+    assert!(rendered.contains("mode"));
+    assert!(rendered.contains("description"));
+    assert!(rendered.contains("review-auth"));
+    assert!(rendered.contains("medium"));
+    assert!(rendered.contains("confirm"));
+    assert!(rendered.contains("args: <ticket-id>"));
     assert!(rendered.contains("review-auth finished successfully"));
 
     let transcript = app.state().transcript(20);

--- a/tests/skill_executor.rs
+++ b/tests/skill_executor.rs
@@ -38,6 +38,24 @@ description: 認証ロジックをレビューする
     dir
 }
 
+fn create_suggest_skill_workspace() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let skills_dir = dir.path().join(".claude/skills/summarise");
+    fs::create_dir_all(&skills_dir).unwrap();
+    fs::write(
+        skills_dir.join("SKILL.md"),
+        r#"---
+name: summarise
+invoke: suggest
+risk: low
+description: Summarise text
+---
+"#,
+    )
+    .unwrap();
+    dir
+}
+
 #[test]
 fn skill_command_requires_confirmation_then_posts_result() {
     let workspace = create_skill_workspace();
@@ -127,4 +145,25 @@ fn run_uses_pending_skill_proposals_from_ai_response() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(rendered.contains("proposal executed"));
+}
+
+#[test]
+fn suggest_only_skill_explains_how_to_run_it() {
+    let workspace = create_suggest_skill_workspace();
+    let mut config = Config::default();
+    config.ai.command = Some("true".into());
+    let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
+
+    app.handle_input_line_for_test("/skill summarise").unwrap();
+
+    let rendered = app
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Skill 'summarise' is propose-only"));
+    assert!(rendered.contains("/run <id>"));
 }

--- a/tests/skill_registry.rs
+++ b/tests/skill_registry.rs
@@ -16,6 +16,7 @@ invoke: confirm
 risk: medium
 allowed-tools: [Read, Grep]
 description: 認証ロジックをレビューする
+args_hint: <ticket-id>
 ---
 
 # Review Auth
@@ -47,6 +48,7 @@ fn scan_reads_valid_skills_and_skips_invalid_frontmatter() {
     assert_eq!(skill.invoke_mode, InvokeMode::Confirm);
     assert_eq!(skill.risk, RiskLevel::Medium);
     assert_eq!(skill.allowed_tools, vec!["Read".to_string(), "Grep".to_string()]);
+    assert_eq!(skill.args_hint.as_deref(), Some("<ticket-id>"));
 }
 
 #[test]
@@ -68,4 +70,10 @@ fn missing_skills_directory_returns_empty_registry() {
     let registry = SkillRegistry::scan(workspace.path());
 
     assert!(registry.skills().is_empty());
+}
+
+#[test]
+fn display_labels_are_human_readable() {
+    assert_eq!(InvokeMode::AutoSafe.to_string(), "auto-safe");
+    assert_eq!(RiskLevel::Low.to_string(), "low");
 }


### PR DESCRIPTION
Closes #6.
Closes #10.

## Summary
- render `/skills` with human-readable risk/mode labels
- surface optional `args_hint` metadata in skill listings
- explain propose-only skills and improve timeout guidance
- extend skill registry and command tests