### PR TITLE
fix: dynamic avatar rendering in UI (fixes #19)

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -166,7 +166,7 @@ impl<'a> Application<'a> {
         let mut renderer =
             if self._terminal_events.is_some() { Some(Renderer::new(out)?) } else { None };
         if let Some(renderer) = renderer.as_mut() {
-            renderer.render(&self.state, self.config)?;
+            renderer.render(&self.state, self.config, &self.avatar_manager)?;
         }
 
         self.start_network()?;
@@ -176,7 +176,7 @@ impl<'a> Application<'a> {
                 return Ok(());
             }
             if let Some(renderer) = renderer.as_mut() {
-                renderer.render(&self.state, self.config)?;
+                renderer.render(&self.state, self.config, &self.avatar_manager)?;
             }
         }
     }
@@ -876,6 +876,7 @@ impl<'a> Application<'a> {
             user_name: self.config.user_name.clone(),
             server_port,
             node_version: env!("CARGO_PKG_VERSION").into(),
+            avatar: self.state.user_avatar.clone(),
         };
         let mut encoder = Encoder::new();
         self.node.network().send(endpoint, encoder.encode(NetMessage::PeerInfo(peer)));

--- a/src/message.rs
+++ b/src/message.rs
@@ -70,6 +70,8 @@ pub struct PeerInfo {
     pub user_name: String,
     pub server_port: u16,
     pub node_version: String,
+    #[serde(default)]
+    pub avatar: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,3 +1,4 @@
+use crate::avatar::loader::AvatarManager;
 use crate::config::Config;
 use crate::state::State;
 use crate::ui::{self};
@@ -23,9 +24,15 @@ impl<W: Write> Renderer<W> {
         Ok(Renderer { terminal: Terminal::new(CrosstermBackend::new(out))? })
     }
 
-    pub fn render(&mut self, state: &State, config: &Config) -> Result<()> {
-        self.terminal
-            .draw(|frame| ui::draw(frame, state, frame.size(), &config.theme, &config.language))?;
+    pub fn render(
+        &mut self,
+        state: &State,
+        config: &Config,
+        avatar_manager: &AvatarManager,
+    ) -> Result<()> {
+        self.terminal.draw(|frame| {
+            ui::draw(frame, state, frame.size(), &config.theme, &config.language, avatar_manager)
+        })?;
         Ok(())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -385,14 +385,20 @@ impl State {
     }
 
     pub fn peer_info_list(&self) -> Vec<(String, String)> {
-        let mut peers = self
-            .peers
-            .values()
-            .filter(|peer| peer.user_name != self.local_user_name)
+        Self::collect_peer_info(&self.local_user_name, self.peers.values())
+    }
+
+    fn collect_peer_info<'a>(
+        local_user_name: &str,
+        peers: impl Iterator<Item = &'a PeerInfo>,
+    ) -> Vec<(String, String)> {
+        let mut list = peers
+            .filter(|peer| peer.user_name != local_user_name)
             .map(|peer| (peer.user_name.clone(), peer.avatar.clone()))
             .collect::<Vec<_>>();
-        peers.sort_by(|a, b| a.0.cmp(&b.0));
-        peers
+        list.sort_by(|a, b| a.0.cmp(&b.0));
+        list.dedup_by(|a, b| a.0 == b.0);
+        list
     }
 
     pub fn peers(&self) -> &HashMap<Endpoint, PeerInfo> {
@@ -899,5 +905,42 @@ mod tests {
         s.input_history_prev();
 
         assert_eq!(s.input_cursor, 5);
+    }
+
+    #[test]
+    fn collect_peer_info_filters_local_and_deduplicates() {
+        let local_user = "alice";
+        let peers = vec![
+            PeerInfo {
+                user_name: "bob".into(),
+                avatar: "neko".into(),
+                server_port: 0,
+                node_version: "".into(),
+            },
+            PeerInfo {
+                user_name: "alice".into(),
+                avatar: "human".into(),
+                server_port: 0,
+                node_version: "".into(),
+            },
+            PeerInfo {
+                user_name: "bob".into(),
+                avatar: "neko".into(),
+                server_port: 1,
+                node_version: "".into(),
+            },
+            PeerInfo {
+                user_name: "charlie".into(),
+                avatar: "claude".into(),
+                server_port: 0,
+                node_version: "".into(),
+            },
+        ];
+
+        let result = State::collect_peer_info(local_user, peers.iter());
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], ("bob".into(), "neko".into()));
+        assert_eq!(result[1], ("charlie".into(), "claude".into()));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -344,6 +344,7 @@ impl State {
             user_name: user.into(),
             server_port: 0,
             node_version: "unknown".into(),
+            avatar: "human_default".into(),
         });
         if !self.users_id.contains_key(user) {
             self.users_id.insert(user.into(), self.last_user_id);
@@ -370,6 +371,16 @@ impl State {
     pub fn peer_names(&self) -> Vec<String> {
         let mut peers = self.peers.values().map(|peer| peer.user_name.clone()).collect::<Vec<_>>();
         peers.sort();
+        peers
+    }
+
+    pub fn peer_info_list(&self) -> Vec<(String, String)> {
+        let mut peers = self
+            .peers
+            .values()
+            .map(|peer| (peer.user_name.clone(), peer.avatar.clone()))
+            .collect::<Vec<_>>();
+        peers.sort_by(|a, b| a.0.cmp(&b.0));
         peers
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -910,7 +910,7 @@ mod tests {
     #[test]
     fn collect_peer_info_filters_local_and_deduplicates() {
         let local_user = "alice";
-        let peers = vec![
+        let peers = [
             PeerInfo {
                 user_name: "bob".into(),
                 avatar: "neko".into(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -378,6 +378,7 @@ impl State {
         let mut peers = self
             .peers
             .values()
+            .filter(|peer| peer.user_name != self.local_user_name)
             .map(|peer| (peer.user_name.clone(), peer.avatar.clone()))
             .collect::<Vec<_>>();
         peers.sort_by(|a, b| a.0.cmp(&b.0));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,14 +7,12 @@ pub mod status_panel;
 use resize::px::RGB;
 use resize::Pixel::RGB8;
 use resize::Type::Lanczos3;
-use tui::backend::CrosstermBackend;
+use tui::backend::Backend;
 use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Modifier, Style};
 use tui::text::{Span, Spans};
 use tui::widgets::{Block, Borders, Paragraph, Wrap};
 use tui::Frame;
-
-use std::io::Write;
 
 use crate::avatar::loader::AvatarManager;
 use crate::commands::CommandManager;
@@ -28,7 +26,7 @@ use crate::ui::status_panel::draw_status_panel;
 use crate::util::split_each;
 
 pub fn draw(
-    frame: &mut Frame<CrosstermBackend<impl Write>>,
+    frame: &mut Frame<impl Backend>,
     state: &State,
     chunk: Rect,
     theme: &Theme,
@@ -118,7 +116,7 @@ pub fn draw(
 }
 
 fn draw_messages_panel(
-    frame: &mut Frame<CrosstermBackend<impl Write>>,
+    frame: &mut Frame<impl Backend>,
     state: &State,
     chunk: Rect,
     theme: &Theme,
@@ -250,12 +248,7 @@ fn parse_content<'a>(content: &'a str, theme: &Theme) -> Vec<Span<'a>> {
     }
 }
 
-fn draw_input_panel(
-    frame: &mut Frame<CrosstermBackend<impl Write>>,
-    state: &State,
-    chunk: Rect,
-    theme: &Theme,
-) {
+fn draw_input_panel(frame: &mut Frame<impl Backend>, state: &State, chunk: Rect, theme: &Theme) {
     let inner_width = (chunk.width - 2) as usize;
     let input = state.input().iter().collect::<String>();
     let input = split_each(input, inner_width)
@@ -278,7 +271,7 @@ fn draw_input_panel(
     frame.set_cursor(chunk.x + 1 + input_cursor.0, chunk.y + 1 + input_cursor.1)
 }
 
-fn draw_video_panel(frame: &mut Frame<CrosstermBackend<impl Write>>, state: &State, chunk: Rect) {
+fn draw_video_panel(frame: &mut Frame<impl Backend>, state: &State, chunk: Rect) {
     let windows = state.windows.values().collect();
     let fb = FrameBuffer::new(windows).block(Block::default().borders(Borders::ALL));
     frame.render_widget(fb, chunk);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,6 +16,7 @@ use tui::Frame;
 
 use std::io::Write;
 
+use crate::avatar::loader::AvatarManager;
 use crate::commands::CommandManager;
 use crate::config::{LanguageConfig, Theme};
 use crate::state::{MessageType, ProgressState, State, SystemMessageType, Window};
@@ -32,6 +33,7 @@ pub fn draw(
     chunk: Rect,
     theme: &Theme,
     language: &LanguageConfig,
+    avatar_manager: &AvatarManager,
 ) {
     // Outer vertical split: [upper(min), input(6)]
     let v_chunks = Layout::default()
@@ -70,7 +72,7 @@ pub fn draw(
             .constraints(layout::right_column_constraints())
             .split(h_chunks[1]);
 
-        draw_peers_panel(frame, state, left_chunks[0]);
+        draw_peers_panel(frame, state, left_chunks[0], avatar_manager);
         draw_room_list_panel(
             frame,
             state.rooms(),
@@ -90,7 +92,7 @@ pub fn draw(
             draw_messages_panel(frame, state, right_chunks[0], theme, language);
         }
 
-        draw_status_panel(frame, state, right_chunks[1]);
+        draw_status_panel(frame, state, right_chunks[1], avatar_manager);
     } else {
         // ── Narrow layout: chat above, ops-ai below ─────────────────────────
         let right_chunks = Layout::default()
@@ -109,7 +111,7 @@ pub fn draw(
             draw_messages_panel(frame, state, right_chunks[0], theme, language);
         }
 
-        draw_status_panel(frame, state, right_chunks[1]);
+        draw_status_panel(frame, state, right_chunks[1], avatar_manager);
     }
 
     draw_input_panel(frame, state, v_chunks[1], theme);

--- a/src/ui/peers_panel.rs
+++ b/src/ui/peers_panel.rs
@@ -7,7 +7,7 @@ use tui::Frame;
 
 use std::io::Write;
 
-use crate::avatar::builtin::render_human;
+use crate::avatar::loader::AvatarManager;
 use crate::avatar::{AvatarSize, AvatarState};
 use crate::state::State;
 use crate::ui::layout::truncate;
@@ -21,13 +21,26 @@ pub fn draw_peers_panel(
     frame: &mut Frame<CrosstermBackend<impl Write>>,
     state: &State,
     chunk: Rect,
+    avatar_manager: &AvatarManager,
 ) {
     let mut lines: Vec<Spans> =
         vec![Spans::from(Span::styled("Peers", Style::default().add_modifier(Modifier::BOLD)))];
 
-    for peer_name in state.peer_names() {
-        // Compact avatar + name line
-        let av = render_human(AvatarState::Online, AvatarSize::Compact);
+    // Local user
+    let local_av =
+        avatar_manager.render(&state.user_avatar, AvatarState::Online, AvatarSize::Compact);
+    lines.push(Spans::from(vec![
+        Span::styled(local_av, Style::default().fg(Color::Green)),
+        Span::raw(" "),
+        Span::styled(
+            truncate(state.local_user_name(), 10),
+            Style::default().fg(Color::LightGreen).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    for (peer_name, avatar_preset) in state.peer_info_list() {
+        let preset = if avatar_preset.is_empty() { "human_default" } else { &avatar_preset };
+        let av = avatar_manager.render(preset, AvatarState::Online, AvatarSize::Compact);
         lines.push(Spans::from(vec![
             Span::styled(av, Style::default().fg(Color::Green)),
             Span::raw(" "),
@@ -35,8 +48,11 @@ pub fn draw_peers_panel(
         ]));
     }
 
-    if lines.len() == 1 {
-        lines.push(Spans::from(Span::styled("(no peers)", Style::default().fg(Color::DarkGray))));
+    if lines.len() == 2 {
+        lines.push(Spans::from(Span::styled(
+            "(no other peers)",
+            Style::default().fg(Color::DarkGray),
+        )));
     }
 
     let panel = Paragraph::new(lines).block(

--- a/src/ui/peers_panel.rs
+++ b/src/ui/peers_panel.rs
@@ -1,11 +1,9 @@
-use tui::backend::CrosstermBackend;
+use tui::backend::Backend;
 use tui::layout::Rect;
 use tui::style::{Color, Modifier, Style};
 use tui::text::{Span, Spans};
 use tui::widgets::{Block, Borders, Paragraph};
 use tui::Frame;
-
-use std::io::Write;
 
 use crate::avatar::loader::AvatarManager;
 use crate::avatar::{AvatarSize, AvatarState};
@@ -18,7 +16,7 @@ use crate::ui::layout::truncate;
 /// When the terminal is too narrow this function should not be called — the
 /// caller is responsible for the visibility decision (see `layout::should_show_side_panels`).
 pub fn draw_peers_panel(
-    frame: &mut Frame<CrosstermBackend<impl Write>>,
+    frame: &mut Frame<impl Backend>,
     state: &State,
     chunk: Rect,
     avatar_manager: &AvatarManager,
@@ -38,7 +36,10 @@ pub fn draw_peers_panel(
         ),
     ]));
 
-    for (peer_name, avatar_preset) in state.peer_info_list() {
+    let remote_peers = state.peer_info_list();
+    let remote_peer_count = remote_peers.len();
+
+    for (peer_name, avatar_preset) in remote_peers {
         let preset = if avatar_preset.is_empty() { "human_default" } else { &avatar_preset };
         let av = avatar_manager.render(preset, AvatarState::Online, AvatarSize::Compact);
         lines.push(Spans::from(vec![
@@ -48,7 +49,7 @@ pub fn draw_peers_panel(
         ]));
     }
 
-    if lines.len() == 2 {
+    if remote_peer_count == 0 {
         lines.push(Spans::from(Span::styled(
             "(no other peers)",
             Style::default().fg(Color::DarkGray),

--- a/src/ui/room_list_panel.rs
+++ b/src/ui/room_list_panel.rs
@@ -1,11 +1,9 @@
-use tui::backend::CrosstermBackend;
+use tui::backend::Backend;
 use tui::layout::Rect;
 use tui::style::{Modifier, Style};
 use tui::text::Span;
 use tui::widgets::{Block, Borders, Paragraph};
 use tui::Frame;
-
-use std::io::Write;
 
 use crate::room::Room;
 use crate::ui::layout::truncate;
@@ -70,7 +68,7 @@ pub fn build_room_lines(rooms: &[Room], active_id: Option<&str>, scroll: usize) 
 }
 
 pub fn draw_room_list_panel(
-    frame: &mut Frame<CrosstermBackend<impl Write>>,
+    frame: &mut Frame<impl Backend>,
     rooms: &[Room],
     active_id: Option<&str>,
     scroll: usize,

--- a/src/ui/status_panel.rs
+++ b/src/ui/status_panel.rs
@@ -7,8 +7,8 @@ use tui::Frame;
 
 use std::io::Write;
 
-use crate::avatar::builtin::render_ai;
-use crate::avatar::{AvatarSize, AvatarState};
+use crate::avatar::loader::AvatarManager;
+use crate::avatar::AvatarState;
 use crate::state::{AiMode, AiState, SkillProposal, State};
 use crate::ui::layout::truncate;
 
@@ -20,9 +20,10 @@ pub fn draw_status_panel(
     frame: &mut Frame<CrosstermBackend<impl Write>>,
     state: &State,
     chunk: Rect,
+    avatar_manager: &AvatarManager,
 ) {
     let avatar_state = ai_state_to_avatar_state(&state.ai_state);
-    let av_art = render_ai(avatar_state, AvatarSize::Normal);
+    let av_art = avatar_manager.render(&state.ai_avatar, avatar_state, state.avatar_size);
 
     let mut lines: Vec<Spans> = Vec::new();
 

--- a/tests/net_message_phase1.rs
+++ b/tests/net_message_phase1.rs
@@ -6,6 +6,7 @@ fn peer_info_round_trips_through_bincode() {
         user_name: "takuro".into(),
         server_port: 4000,
         node_version: "0.1.0".into(),
+        avatar: "neko".into(),
     });
 
     let encoded = bincode::serialize(&message).expect("message should serialize");
@@ -16,6 +17,7 @@ fn peer_info_round_trips_through_bincode() {
             assert_eq!(info.user_name, "takuro");
             assert_eq!(info.server_port, 4000);
             assert_eq!(info.node_version, "0.1.0");
+            assert_eq!(info.avatar, "neko");
         }
         other => panic!("unexpected message: {:?}", other),
     }


### PR DESCRIPTION
Fixes #19

### Changes:
1. Added `avatar` field to `PeerInfo` structure to sync it over the network.
2. Updated `Application` and `State` to properly initialize `PeerInfo` with `user_avatar`.
3. Modified `Renderer::render` and `ui::draw` to pass down `AvatarManager`.
4. Refactored `draw_status_panel` and `draw_peers_panel` to use `avatar_manager.render()` with the correct presets.
5. Added the local user to the Peers panel list to ensure they can see their own selected avatar.
6. Maintained backward compatibility and fallback mechanisms for missing avatar configurations.