### PR TITLE
docs: translate README to English and add AI assistant guidance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+This file provides guidance to OpenAI Codex and other agent runtimes when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+cargo build
+cargo build --release
+
+# Run
+cargo run -- --username <name>
+
+# Test
+cargo test                          # All tests
+cargo test <pattern>                # Tests matching pattern
+cargo test --lib                    # Unit tests only
+cargo test --test <file>            # Specific integration test (tests/<file>.rs)
+cargo test -- --nocapture           # Show println output
+
+# Lint & format
+cargo fmt
+cargo clippy -- -D warnings
+
+# Feature flags
+cargo build --features avatar-ffi   # FFI avatar plugin loading
+cargo test --features ui-test       # UI test helpers
+```
+
+Config file is auto-created at `~/.config/triadchat/config.toml` on first run.
+
+## Architecture
+
+**triadchat** is a terminal LAN chat application with an embedded AI clerk. Rust binary using:
+- `message-io` for networking (UDP multicast discovery + TCP)
+- `tui-rs` + crossterm for the TUI
+- Claude Code CLI (`claude -p`) as the AI sidecar
+
+### Module layout
+
+| Module | Purpose |
+|--------|---------|
+| `src/application/` | Event loop; wires network, TUI, commands, AI |
+| `src/state.rs` | All runtime state: messages, input, history, rooms, AI state |
+| `src/ai/` | `AiMediator` → `SidecarAdapter` → `claude -p` subprocess |
+| `src/room/` | `RoomEngine` multi-room state machine + transcript writer |
+| `src/commands/` | `/`-prefixed command parser |
+| `src/skill/` | Skill registry and executor |
+| `src/ui/` | TUI layout panels |
+| `src/avatar/` | Avatar rendering + optional FFI plugin |
+| `src/config.rs` | TOML config |
+| `src/message.rs` | Wire types: `AiPayload`, `PeerInfo`, `StructuredOutput` |
+| `tests/` | Integration tests |
+
+### Important design rules
+
+1. **Single mutable state** — `State` in `src/state.rs` is the only mutable runtime struct. All mutations go through its public methods. Do not access fields directly from outside the module.
+
+2. **AI task pipeline** — adding a new AI capability requires:
+   - A variant in `AiTask` (`src/ai/mod.rs`)
+   - A prompt builder in `src/ai/prompt.rs`
+   - A match arm in `AiMediator::request`
+
+3. **Commands** — each `/`-command family lives in `src/commands/<family>_cmd.rs`. Register new commands in `application/mod.rs` via `CommandManager::with(...)`.
+
+4. **No `unwrap()` in production** — use `?` with `anyhow::Context` for error propagation. Reserve `unwrap()` / `expect()` for tests and provably-unreachable states.
+
+5. **Input history** — `State::input_history` (Vec<String>) is appended on each non-whitespace submit. Navigation state is `history_cursor: Option<usize>` and `history_draft: String`.
+
+### Data flow summary
+
+```
+KeyEvent
+  └─► application::handle_input
+        ├─► State::input_write / input_history_prev / input_history_next
+        └─► CommandManager::find_command
+              ├─► ParsedCommand::Action  → network / file I/O
+              └─► ParsedCommand::App    → AppCommand handler
+                    └─► AiMediator::request (async, spawned task)
+                          └─► SidecarAdapter: claude -p <prompt>
+                                └─► parse_ai_payload → State::add_ai_message
+```
+
+## Coding conventions
+
+- `cargo fmt` before every commit.
+- `cargo clippy -- -D warnings` — all warnings must be resolved.
+- Use `anyhow` for application errors, `thiserror` for typed library errors.
+- Prefer `&str` / `&[T]` parameters over owned types unless ownership is needed.
+- Module visibility: default private, `pub(crate)` for internal sharing, `pub` only for the public API.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+cargo build
+cargo build --release
+
+# Run
+cargo run -- --username <name>
+
+# Test
+cargo test                          # All tests
+cargo test <pattern>                # Tests matching pattern
+cargo test --lib                    # Unit tests only
+cargo test --test <file>            # Specific integration test (tests/<file>.rs)
+cargo test -- --nocapture           # Show println output
+
+# Lint & format
+cargo fmt
+cargo clippy -- -D warnings
+
+# Feature flags
+cargo build --features avatar-ffi   # Enable dynamic avatar plugin loading via FFI
+cargo test --features ui-test       # Enable UI test helpers
+```
+
+Config file is written automatically on first run to `~/.config/triadchat/config.toml`.
+
+## Architecture
+
+**triadchat** is a terminal LAN chat app with an embedded AI clerk. It is a Rust binary built on `message-io` (networking), `tui-rs` + crossterm (TUI), and Claude Code (`claude -p`) as a sidecar AI process.
+
+### Module layout
+
+| Module | Purpose |
+|--------|---------|
+| `src/application/` | Top-level event loop; wires together network, TUI, commands, and AI |
+| `src/state.rs` | Central mutable state: messages, input buffer, history, rooms, AI state |
+| `src/ai/` | AI integration: `AiMediator` dispatches `AiTask` variants → `SidecarAdapter` → `claude -p` |
+| `src/room/` | `RoomEngine` (multi-room state machine) + `transcript.rs` (YAML/JSON log) |
+| `src/commands/` | `/`-prefixed command parser; each submodule handles one command family |
+| `src/skill/` | Skill registry and executor; runs `.claude/skills/<name>` via sidecar |
+| `src/ui/` | TUI layout panels: messages, peers, room list, status |
+| `src/avatar/` | Avatar rendering; optional FFI plugin loading (`avatar-ffi` feature) |
+| `src/config.rs` | TOML config struct; auto-created at `~/.config/triadchat/config.toml` |
+| `src/message.rs` | Shared wire types (serde): `AiPayload`, `PeerInfo`, `StructuredOutput`, IDs |
+| `tests/` | Integration tests (each `.rs` file is a separate test binary) |
+
+### Data flow
+
+```
+Terminal events
+      │
+      ▼
+application::mod  ──► CommandManager ──► AppCommand / Action
+      │
+      ├──► State (input, messages, rooms, AI state)
+      │
+      ├──► AiMediator.request(AiTask, transcript, last_messages)
+      │         └──► SidecarAdapter ("claude -p" subprocess)
+      │                   └──► parse_ai_payload → AiPayload
+      │
+      └──► TUI renderer (ui/ panels)
+```
+
+### Key types
+
+- **`State`** (`src/state.rs`) — single mutable struct holding all runtime state. Input history (`input_history`, `history_cursor`, `history_draft`) lives here. Mutations go through methods on `State`; no field is mutated directly from outside.
+- **`AiTask`** — enum of AI task kinds (Summary, Todos, Decisions, Intervene, Companion, Mention). Each maps to a prompt builder in `src/ai/prompt.rs`.
+- **`AiMode`** — Clerk / Listener / Moderator / Operator / Companion. Controls when the AI intervenes automatically.
+- **`AppCommand`** — parsed result of `/`-commands; handled in `application/mod.rs`.
+
+### AI sidecar
+
+The AI runs as a subprocess (`claude -p <prompt>`). `SidecarAdapter` manages the process, timeout, and stdout capture. `parse_ai_payload` in `src/ai/parser.rs` converts the raw output into `AiPayload` (text + optional `StructuredOutput`).
+
+### Networking
+
+Peer discovery via UDP multicast (`238.255.0.1:5877`); data transport over TCP (random port by default). `message-io` handles both. Phase 1 adds explicit Room negotiation messages (`src/net_message_phase1.rs`).
+
+### Input history
+
+`State::input_history` is a `Vec<String>` appended on each non-whitespace submit. Up/Down arrow keys call `input_history_prev` / `input_history_next`. A `history_draft` field saves unsent text before entering history mode; it is restored when the user presses Down past the last entry. All history logic is unit-tested inside `src/state.rs`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,99 @@
+# GEMINI.md
+
+This file provides guidance to Gemini CLI when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+cargo build
+cargo build --release
+
+# Run
+cargo run -- --username <name>
+
+# Test
+cargo test                          # All tests
+cargo test <pattern>                # Tests matching pattern
+cargo test --lib                    # Unit tests only
+cargo test --test <file>            # Specific integration test (tests/<file>.rs)
+cargo test -- --nocapture           # Show println output
+
+# Lint & format
+cargo fmt
+cargo clippy -- -D warnings
+
+# Feature flags
+cargo build --features avatar-ffi   # Enable dynamic avatar plugin loading via FFI
+cargo test --features ui-test       # Enable UI test helpers
+```
+
+Config file is auto-created at `~/.config/triadchat/config.toml` on first run.
+
+## Architecture
+
+**triadchat** is a terminal LAN chat application with an embedded AI clerk. It is a Rust binary built on:
+- `message-io` — UDP multicast peer discovery + TCP data transport
+- `tui-rs` + crossterm — terminal UI
+- Claude Code (`claude -p`) — AI sidecar subprocess
+
+### Module layout
+
+| Module | Purpose |
+|--------|---------|
+| `src/application/` | Top-level event loop; wires together network, TUI, commands, and AI |
+| `src/state.rs` | Central mutable state: messages, input buffer, history, rooms, AI state |
+| `src/ai/` | AI integration: `AiMediator` dispatches `AiTask` variants → `SidecarAdapter` → `claude -p` |
+| `src/room/` | `RoomEngine` (multi-room state machine) + `transcript.rs` (YAML/JSON log) |
+| `src/commands/` | `/`-prefixed command parser; each submodule handles one command family |
+| `src/skill/` | Skill registry and executor; runs `.claude/skills/<name>` via sidecar |
+| `src/ui/` | TUI layout panels: messages, peers, room list, status |
+| `src/avatar/` | Avatar rendering; optional FFI plugin loading (`avatar-ffi` feature) |
+| `src/config.rs` | TOML config struct; auto-created at `~/.config/triadchat/config.toml` |
+| `src/message.rs` | Shared wire types (serde): `AiPayload`, `PeerInfo`, `StructuredOutput`, IDs |
+| `tests/` | Integration tests (each `.rs` file is a separate test binary) |
+
+### Data flow
+
+```
+Terminal events
+      │
+      ▼
+application::mod  ──► CommandManager ──► AppCommand / Action
+      │
+      ├──► State (input, messages, rooms, AI state)
+      │
+      ├──► AiMediator.request(AiTask, transcript, last_messages)
+      │         └──► SidecarAdapter ("claude -p" subprocess)
+      │                   └──► parse_ai_payload → AiPayload
+      │
+      └──► TUI renderer (ui/ panels)
+```
+
+### Key types
+
+- **`State`** (`src/state.rs`) — single mutable struct holding all runtime state. Input history (`input_history`, `history_cursor`, `history_draft`) lives here. All mutations go through methods on `State`.
+- **`AiTask`** — enum of AI task kinds (Summary, Todos, Decisions, Intervene, Companion, Mention). Each maps to a prompt builder in `src/ai/prompt.rs`.
+- **`AiMode`** — Clerk / Listener / Moderator / Operator / Companion. Controls when the AI intervenes automatically.
+- **`AppCommand`** — parsed result of `/`-commands; handled in `application/mod.rs`.
+
+### AI sidecar
+
+The AI runs as a subprocess (`claude -p <prompt>`). `SidecarAdapter` manages the process, timeout (default 30 s), and stdout capture. Prompts are truncated to 50 000 characters. `parse_ai_payload` in `src/ai/parser.rs` converts raw output into `AiPayload` (text + optional `StructuredOutput`).
+
+### Networking
+
+Peer discovery via UDP multicast (`238.255.0.1:5877`); data transport over TCP (random port by default). Phase 1 adds explicit Room negotiation messages (`src/net_message_phase1.rs`).
+
+### Input history
+
+`State::input_history` is a `Vec<String>` appended on each non-whitespace submit. Up/Down arrow keys call `input_history_prev` / `input_history_next`. A `history_draft` field saves unsent text before entering history mode and is restored when the user navigates past the last entry.
+
+## Coding conventions
+
+- Run `cargo fmt` before committing.
+- Run `cargo clippy -- -D warnings` and fix all warnings.
+- Use `anyhow` for application-level errors; `thiserror` for library-level typed errors.
+- Never use `unwrap()` in production paths — use `?` or `.with_context(...)`.
+- All state mutations go through methods on `State`; do not access fields directly from outside the module.
+- New AI task types require: a variant in `AiTask`, a prompt builder in `src/ai/prompt.rs`, and a match arm in `AiMediator::request`.

--- a/README.md
+++ b/README.md
@@ -2,76 +2,173 @@
 
 > Terminal chat with a built-in AI clerk — no server, no GUI, just your LAN and a terminal.
 
-**ai-termchat** は [termchat](https://github.com/lemunozm/termchat) を fork し、「人間 + AI」または「人間A・人間B・AI」の3者会話型オペレーション端末へ拡張するプロジェクトです。
+**ai-termchat** is a fork of [termchat](https://github.com/lemunozm/termchat), extended into an "human + AI" or "human A · human B · AI" three-party operations terminal.
 
-ターミナルから出ずに会話するだけで、TODO・決定事項が自動で構造化され、Claude Code skills に接続できます。
+Chat in your terminal and the AI clerk automatically structures TODOs and decisions, and can trigger Claude Code skills on demand.
 
 ---
 
-## コアコンセプト
+## Core Concept
 
 ```
-10:01 takuro: この関数、責務が多すぎる
-10:02 tanaka: 認証周りを切り出したい
-10:03 ops-ai ✦ 決定: auth を service 層へ分離 (既存 IF 維持)
-               TODO: takuro — auth 抽出設計
-                     tanaka — 回帰確認
-               提案: [1] /skill review-auth
+10:01 takuro: this function has too many responsibilities
+10:02 tanaka:  want to extract the auth layer
+10:03 ops-ai ✦ Decision: separate auth into service layer (keep existing IF)
+               TODO: takuro — design auth extraction
+                     tanaka — regression check
+               Proposal: [1] /skill review-auth
 ```
 
-会話するだけで AI clerk が構造化してくれる。コマンドを覚えなくても動く。
+Just talk — the AI clerk structures the conversation for you. No commands to memorise.
 
 ---
 
-## 特徴
+## Features
 
-- **サーバ不要** — LAN multicast で自動ピア発見、TCP 直結
-- **TUI** — ターミナルのみで完結
-- **AI clerk** — `/summary` `/todos` `/decisions` で会話を即座に構造化
-- **Claude Code skills 連携** — `/skill <name>` で `.claude/skills/` のスキルを実行
-- **言語設定** — `config.toml` で AI 出力言語・UI 言語を設定 (ja/en/zh/ko)
-- **Avatar plugin** — ASCII アバターをプラグインで差し替え可能 (Phase 2)
-
----
-
-## ステータス
-
-現在は設計フェーズです。実装は以下のフェーズで進めます。
-
-| フェーズ | スコープ | ステータス |
-|----------|----------|-----------|
-| **Phase 0** | 1人+AI。`/summary` `/todos` `/decisions` | 📋 設計中 |
-| **Phase 1** | LAN 2台。2人+AI の3者 Room。`/skill` 実行 | 📋 未着手 |
-| **Phase 2** | ASCII avatar プラグイン + 3ペイン TUI | 📋 未着手 |
+- **No server required** — LAN multicast peer discovery, direct TCP connections
+- **TUI** — runs entirely in the terminal
+- **AI clerk** — `/summary` `/todos` `/decisions` instantly structure the conversation
+- **Claude Code skill integration** — `/skill <name>` executes skills from `.claude/skills/`
+- **AI modes** — Clerk / Companion / Listener / Moderator / Operator
+- **`@ops-ai` mention** — direct replies from the AI inside any conversation
+- **Input history** — Up/Down arrow keys navigate previously sent messages
+- **Language config** — set AI output and UI language in `config.toml` (ja/en/zh/ko)
+- **Avatar plugin** — swap ASCII avatars via preset names or FFI plugin (optional)
 
 ---
 
-## ドキュメント
+## Status
 
-| ファイル | 内容 |
-|----------|------|
-| [docs/IDEA.md](docs/IDEA.md) | プロダクトアイデア・コンセプト |
-| [docs/SPEC.md](docs/SPEC.md) | 機能仕様書 (v0.3) |
-| [docs/PLAN.md](docs/PLAN.md) | PR 単位の実装計画 |
+| Phase | Scope | Status |
+|-------|-------|--------|
+| **Phase 0** | Solo + AI. `/summary` `/todos` `/decisions` `/skill` | ✅ Implemented |
+| **Phase 1** | LAN 2-player. 2-person + AI 3-party room. `/skill` execution | 🚧 In progress |
+| **Phase 2** | ASCII avatar plugin + 3-pane TUI | 📋 Planned |
 
 ---
 
-## 技術スタック
+## Quick Start
 
-- **言語:** Rust (edition 2021, MSRV 1.75)
-- **ネットワーク:** [message-io](https://github.com/lemunozm/message-io) (UDP multicast + TCP)
+### Prerequisites
+
+- Rust 1.75+ (`rustup update stable`)
+- [Claude Code CLI](https://claude.ai/code) installed and authenticated (`claude` in PATH)
+
+### Build & Run
+
+```bash
+git clone https://github.com/takurot/ai-termchat
+cd ai-termchat
+cargo run -- --username <your-name>
+```
+
+### Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--username <NAME>` | `-u` | Display name (default: system username) |
+| `--discovery <IP:PORT>` | `-d` | Multicast address (default: `238.255.0.1:5877`) |
+| `--tcp-server-port <PORT>` | `-t` | TCP listen port (default: random) |
+| `--quiet-mode` | `-q` | Disable terminal bell |
+| `--theme <dark\|light>` | | Color theme (default: dark) |
+
+---
+
+## Configuration
+
+Config is auto-created at `~/.config/triadchat/config.toml` on first run.
+
+```toml
+[ai]
+enabled = true
+timeout_secs = 30
+# command = "/path/to/claude"   # override if claude is not in PATH
+
+[language]
+ai_output = "en"   # ja | en | zh | ko
+ui = "en"
+
+[user]
+avatar = "human_default"
+ai_avatar = "ai_default"
+
+[security]
+default_permission = "confirm-required"
+trusted_peers = []
+```
+
+---
+
+## In-App Commands
+
+| Command | Description |
+|---------|-------------|
+| `/summary` | AI summary of the conversation |
+| `/todos` | Extract TODO items |
+| `/decisions` | Extract decision items |
+| `/skill <name> [args]` | Run a Claude Code skill |
+| `/skills` | List available skills |
+| `/room create [peers] [--ai <mode>]` | Create a room |
+| `/room list` | List rooms |
+| `/room switch <id>` | Switch active room |
+| `/peers` | Show connected peers |
+| `/avatar set <target> <preset>` | Change avatar preset |
+| `/avatar list` | List available presets |
+| `/ai mode <mode>` | Change AI mode |
+| `/help` | Show help |
+
+### AI Modes
+
+| Mode | Behaviour |
+|------|-----------|
+| `clerk` | Intervenes after several human messages to summarise |
+| `companion` | Responds conversationally to every message |
+| `listener` | Silent — only responds to explicit `/summary` etc. |
+| `moderator` | Summarises periodically at higher frequency |
+| `operator` | Proposes skill executions proactively |
+
+---
+
+## Key Bindings
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send message |
+| `Up` / `Down` | Navigate input history |
+| `←` / `→` | Move cursor |
+| `Ctrl+A` / `Ctrl+E` | Jump to start / end of input |
+| `Ctrl+C` | Quit |
+| `Page Up` / `Page Down` | Scroll message history |
+
+---
+
+## Tech Stack
+
+- **Language:** Rust (edition 2021, MSRV 1.75)
+- **Networking:** [message-io](https://github.com/lemunozm/message-io) (UDP multicast + TCP)
 - **TUI:** [tui-rs](https://github.com/fdehau/tui-rs) + crossterm
 - **AI:** Claude Code sidecar (`claude -p`)
-- **設定:** TOML
+- **Config:** TOML
 
 ---
 
-## ベース
+## Documentation
+
+| File | Contents |
+|------|----------|
+| [CLAUDE.md](CLAUDE.md) | Claude Code guidance — build commands, architecture |
+| [docs/IDEA.md](docs/IDEA.md) | Product idea and concept |
+| [docs/SPEC.md](docs/SPEC.md) | Feature specification (v0.3) |
+| [docs/PLAN.md](docs/PLAN.md) | PR-level implementation plan |
+
+---
+
+## Based On
 
 termchat v1.3.1 — [github.com/lemunozm/termchat](https://github.com/lemunozm/termchat)
 
 ---
 
-## ライセンス
+## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary

- **README.md** — full English rewrite; updated feature list (input history, AI modes, `@ops-ai` mention, avatar presets), Phase 0 marked as implemented, quick-start, config reference, key bindings table, and in-app command reference
- **CLAUDE.md** — new file with build/test/lint commands and architecture overview for Claude Code
- **GEMINI.md** — equivalent guidance file for Gemini CLI
- **AGENTS.md** — equivalent guidance file for OpenAI Codex and other agent runtimes; includes data-flow diagram and design rules

## Test plan

- [ ] Confirm README renders correctly on GitHub (tables, code blocks)
- [ ] Confirm `cargo build` and `cargo test` commands in all three guide files match the actual project
- [ ] Confirm CLAUDE.md is picked up by Claude Code on next session open