### PR TITLE
Implement peer trust, room sync, and manual peer connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "triadchat"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triadchat"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["lemunozm <lemunozm@gmail.com>"]
 description = "Terminal chat with a built-in AI clerk"
 edition = "2021"

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,7 +1,8 @@
 use std::io::ErrorKind;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs};
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{Event as TermEvent, KeyCode, KeyEvent, KeyModifiers};
 use message_io::events::EventReceiver;
@@ -17,6 +18,7 @@ use crate::avatar::loader::AvatarManager;
 use crate::avatar::{AvatarSize, AvatarState};
 use crate::commands::ai_cmd::AiCommand;
 use crate::commands::avatar_cmd::AvatarCommand;
+use crate::commands::peer_cmd::{PeerCommand, TrustCommand};
 use crate::commands::room_cmd::{PeersCommand, RoomCommand};
 use crate::commands::send_file::SendFileCommand;
 use crate::commands::skill_cmd::{CancelCommand, RunCommand, SkillCommand, SkillsCommand};
@@ -24,7 +26,7 @@ use crate::commands::summary_cmd::SummaryCommand;
 use crate::commands::{
     AppCommand, AvatarCommandKind, CommandManager, ParsedCommand, SummaryCommandKind,
 };
-use crate::config::Config;
+use crate::config::{Config, DefaultPermission};
 use crate::encoder::{self, Encoder};
 use crate::message::{AiIntent, AiPayload, Chunk, NetMessage, PeerInfo, SkillResultPayload};
 use crate::room::transcript::TranscriptEntry;
@@ -32,7 +34,7 @@ use crate::room::{MemberKind, Room};
 use crate::renderer::Renderer;
 use crate::state::{
     AiFrequency, AiMode, AiState, ChatMessage, CursorMovement, MessageType, ScrollMovement, State,
-    Window,
+    Window, PeerReadiness,
 };
 use crate::skill::executor::{PendingSkillExecution, SkillExecutor};
 use crate::skill::registry::{InvokeMode, RiskLevel};
@@ -45,6 +47,7 @@ pub enum Signal {
     AiResponse(AiPayload),
     AiFailed(String),
     SkillDone(SkillResultPayload),
+    DiscoveryRetry,
     Close(Option<Error>),
 }
 
@@ -62,6 +65,8 @@ pub struct Application<'a> {
     avatar_manager: AvatarManager,
     test_mode: bool,
     local_server_port: Option<u16>,
+    config_file_path: Option<PathBuf>,
+    discovery_retries_remaining: usize,
 }
 
 impl<'a> Application<'a> {
@@ -106,8 +111,10 @@ impl<'a> Application<'a> {
         let commands = CommandManager::default()
             .with(SendFileCommand)
             .with(AiCommand)
+            .with(PeerCommand)
             .with(RoomCommand)
             .with(PeersCommand)
+            .with(TrustCommand)
             .with(SkillsCommand)
             .with(SkillCommand)
             .with(RunCommand)
@@ -147,6 +154,11 @@ impl<'a> Application<'a> {
             .map(|d| d.join("triadchat").join("avatars"))
             .unwrap_or_else(|| std::path::PathBuf::from("/tmp/triadchat-avatars"));
         let avatar_manager = AvatarManager::new(avatar_dir);
+        let config_file_path = if collect_terminal_events {
+            Config::config_file_path()
+        } else {
+            Some(Config::config_file_path_with_base(workspace.join(".triadchat-test-config")))
+        };
 
         Ok(Self {
             config,
@@ -162,6 +174,8 @@ impl<'a> Application<'a> {
             avatar_manager,
             test_mode: !collect_terminal_events,
             local_server_port: None,
+            config_file_path,
+            discovery_retries_remaining: 0,
         })
     }
 
@@ -189,7 +203,14 @@ impl<'a> Application<'a> {
         let (_, server_addr) = self.node.network().listen(Transport::FramedTcp, server_addr)?;
         self.local_server_port = Some(server_addr.port());
         self.node.network().listen(Transport::Udp, self.config.discovery_addr)?;
+        self.discovery_retries_remaining = 5;
+        self.state.add_system_info_message(format!(
+            "Listening on tcp://127.0.0.1:{} and discovering via {}",
+            server_addr.port(),
+            self.config.discovery_addr
+        ));
         self.announce_presence()?;
+        self.schedule_discovery_retry();
         Ok(())
     }
 
@@ -241,6 +262,7 @@ impl<'a> Application<'a> {
                 Signal::AiResponse(payload) => self.process_ai_response(payload),
                 Signal::AiFailed(error) => self.process_ai_failure(error),
                 Signal::SkillDone(payload) => self.process_skill_done(payload),
+                Signal::DiscoveryRetry => self.handle_discovery_retry(),
                 Signal::Close(error) => {
                     self.node.stop();
                     return match error {
@@ -258,6 +280,9 @@ impl<'a> Application<'a> {
             NetMessage::HelloLan(user, server_port) => {
                 let server_addr = (endpoint.addr().ip(), server_port);
                 if user != self.config.user_name {
+                    if self.state.peer_names().iter().any(|known| known == &user) {
+                        return;
+                    }
                     let mut try_connect = || -> Result<()> {
                         let (user_endpoint, _) =
                             self.node.network().connect_sync(Transport::FramedTcp, server_addr)?;
@@ -271,8 +296,11 @@ impl<'a> Application<'a> {
                 }
             }
             NetMessage::HelloUser(user) => {
+                let already_ready = self.state.peer_is_ready(&user);
                 self.state.connected_user(endpoint, &user);
-                self.send_peer_info(endpoint);
+                if !already_ready {
+                    self.send_peer_info(endpoint);
+                }
                 self.righ_the_bell();
             }
             NetMessage::UserMessage(content) => {
@@ -337,22 +365,23 @@ impl<'a> Application<'a> {
             NetMessage::PeerInfo(peer) => {
                 self.state.connected_user(endpoint, &peer.user_name);
                 self.state.record_peer(endpoint, peer.clone());
-                let fingerprint = self
-                    .state
-                    .peer_fingerprint(endpoint)
-                    .expect("peer fingerprint should exist after record");
-                if !self.state.is_trusted_peer(&fingerprint) {
-                    self.state.trust_peer_fingerprint(fingerprint.clone());
-                    self.persist_trusted_peer_fingerprint(&fingerprint);
+                if let Some(fingerprint) = self.state.peer_fingerprint(endpoint) {
+                    let trust_state = if self.state.is_trusted_peer(&fingerprint) {
+                        "trusted"
+                    } else {
+                        "untrusted"
+                    };
                     self.state.add_system_info_message(format!(
-                        "trusted peer added: {} ({})",
-                        peer.user_name, fingerprint
+                        "peer ready: {} [{}] fp={}",
+                        peer.user_name,
+                        trust_state,
+                        short_fingerprint(&fingerprint)
                     ));
                 }
             }
-            NetMessage::RoomCreate(room_id, member_ids) => {
+            NetMessage::RoomCreate(room_id, member_ids, ai_mode) => {
                 if member_ids.iter().any(|member_id| member_id == &self.config.user_name) {
-                    let room = self.state.accept_room(&room_id, &member_ids);
+                    let room = self.state.accept_room(&room_id, &member_ids, ai_mode);
                     self.state.add_system_info_message(format!("joined room {}", room.id));
                     self.node
                         .network()
@@ -518,8 +547,17 @@ impl<'a> Application<'a> {
                     ));
                     return;
                 }
+                if let Some(not_ready_peer) =
+                    peers.iter().find(|peer| !self.state.peer_is_ready(peer))
+                {
+                    self.state.add_system_error_message(format!(
+                        "peer '{}' is not ready yet; still exchanging peer info.",
+                        not_ready_peer
+                    ));
+                    return;
+                }
 
-                let room = self.state.create_room(&peers, ai_mode);
+                let room = self.state.create_room(&peers, ai_mode.clone());
                 let member_ids =
                     room.members.iter().map(|member| member.id.clone()).collect::<Vec<_>>();
                 for endpoint in self.state.all_user_endpoints() {
@@ -530,6 +568,7 @@ impl<'a> Application<'a> {
                                 self.encoder.encode(NetMessage::RoomCreate(
                                     room.id.clone(),
                                     member_ids.clone(),
+                                    ai_mode.clone(),
                                 )),
                             );
                         }
@@ -570,6 +609,17 @@ impl<'a> Application<'a> {
                     self.state.add_system_info_message(self.peers_text());
                 }
             }
+            AppCommand::PeerConnect(target) => {
+                if let Err(error) = self.connect_peer_target(&target) {
+                    self.state.add_system_error_message(format!(
+                        "failed to connect to {}: {}",
+                        target, error
+                    ));
+                }
+            }
+            AppCommand::TrustList => self.state.add_system_info_message(self.trust_list_text()),
+            AppCommand::TrustAdd(target) => self.trust_peer_target(&target),
+            AppCommand::TrustRemove(target) => self.untrust_peer_target(&target),
             AppCommand::Skills => {
                 if self.state.skill_registry().skills().is_empty() {
                     self.state.add_system_info_message(
@@ -610,12 +660,46 @@ impl<'a> Application<'a> {
                     self.state.add_system_error_message(format!("unknown proposal id: {}", index));
                     return;
                 };
-                if !proposal.trusted {
-                    let source = proposal.source_peer.unwrap_or_else(|| "unknown peer".into());
+                let source = proposal.source_peer.clone();
+                let is_remote = source.is_some();
+                let permission = self.config.security.default_permission_policy();
+                let currently_trusted = source
+                    .as_deref()
+                    .and_then(|peer| self.state.peer_fingerprint_by_name(peer))
+                    .map(|fingerprint| self.state.is_trusted_peer(&fingerprint))
+                    .unwrap_or(proposal.trusted);
+                if is_remote && matches!(permission, DefaultPermission::DenyRemoteExec) {
+                    self.state.add_system_error_message(
+                        "remote proposals are disabled by security.default_permission".into(),
+                    );
+                    return;
+                }
+                if is_remote && !currently_trusted {
+                    let source = source.unwrap_or_else(|| "unknown peer".into());
                     self.state.add_system_error_message(format!(
-                        "permission denied: proposal {} came from untrusted peer {}",
-                        index, source
+                        "permission denied: proposal {} came from untrusted peer {}. Use /trust add {} first.",
+                        index, source, source
                     ));
+                    return;
+                }
+                if is_remote && matches!(permission, DefaultPermission::ConfirmRequired) {
+                    let Some(meta) =
+                        self.state.skill_registry().find(&proposal.skill_name).cloned()
+                    else {
+                        self.state.add_system_error_message(format!(
+                            "unknown skill: {}",
+                            proposal.skill_name
+                        ));
+                        return;
+                    };
+                    let prompt = format!(
+                        "[{}] Execute remote proposal from {}? [y/n]",
+                        meta.name,
+                        source.unwrap_or_else(|| "unknown peer".into())
+                    );
+                    self.state
+                        .queue_skill_confirmation(PendingSkillExecution { meta, args: Vec::new() });
+                    self.state.add_system_info_message(prompt);
                     return;
                 }
                 self.queue_or_run_skill(proposal.skill_name, Vec::new());
@@ -899,14 +983,8 @@ impl<'a> Application<'a> {
     }
 
     pub fn connect_peer_for_test(&mut self, server_port: u16) -> Result<()> {
-        let server_addr = (Ipv4Addr::LOCALHOST, server_port);
-        let (endpoint, _) = self.node.network().connect_sync(Transport::FramedTcp, server_addr)?;
-        self.node.network().send(
-            endpoint,
-            self.encoder.encode(NetMessage::HelloUser(self.config.user_name.clone())),
-        );
-        self.send_peer_info(endpoint);
-        Ok(())
+        let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, server_port));
+        self.connect_peer_addr(server_addr)
     }
 
     pub fn righ_the_bell(&self) {
@@ -939,6 +1017,46 @@ impl<'a> Application<'a> {
         let message = NetMessage::HelloLan(self.config.user_name.clone(), server_port);
         self.node.network().send(discovery_endpoint, self.encoder.encode(message));
         Ok(())
+    }
+
+    fn schedule_discovery_retry(&self) {
+        self.node.signals().send_with_timer(Signal::DiscoveryRetry, Duration::from_millis(250));
+    }
+
+    fn handle_discovery_retry(&mut self) {
+        if !self.state.peer_names().is_empty() || self.discovery_retries_remaining == 0 {
+            if self.state.peer_names().is_empty() {
+                self.state.add_system_info_message(
+                    "No peers discovered yet. You can retry discovery or use /peer connect <host:port>."
+                        .into(),
+                );
+            }
+            return;
+        }
+        self.discovery_retries_remaining = self.discovery_retries_remaining.saturating_sub(1);
+        let _ = self.announce_presence();
+        if self.discovery_retries_remaining > 0 {
+            self.schedule_discovery_retry();
+        }
+    }
+
+    fn connect_peer_addr(&mut self, server_addr: SocketAddr) -> Result<()> {
+        let (endpoint, _) = self.node.network().connect_sync(Transport::FramedTcp, server_addr)?;
+        self.node.network().send(
+            endpoint,
+            self.encoder.encode(NetMessage::HelloUser(self.config.user_name.clone())),
+        );
+        self.send_peer_info(endpoint);
+        self.state.add_system_info_message(format!("connecting to peer at {}", server_addr));
+        Ok(())
+    }
+
+    fn connect_peer_target(&mut self, target: &str) -> Result<()> {
+        let server_addr = target
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("no socket address resolved"))?;
+        self.connect_peer_addr(server_addr)
     }
 
     fn queue_or_run_skill(&mut self, name: String, args: Vec<String>) {
@@ -1034,22 +1152,83 @@ impl<'a> Application<'a> {
     }
 
     fn persist_trusted_peer_fingerprint(&self, fingerprint: &str) {
-        let Some(path) = crate::config::Config::config_file_path() else {
+        self.update_stored_config(|stored| {
+            if !stored.security.trusted_peers.iter().any(|known| known == fingerprint) {
+                stored.security.trusted_peers.push(fingerprint.to_string());
+            }
+        });
+    }
+
+    fn remove_trusted_peer_fingerprint(&self, fingerprint: &str) {
+        self.update_stored_config(|stored| {
+            stored.security.trusted_peers.retain(|known| known != fingerprint);
+        });
+    }
+
+    fn update_stored_config(&self, update: impl FnOnce(&mut Config)) {
+        let Some(path) = self.config_file_path.as_ref() else {
             return;
         };
-        let Ok(raw) = std::fs::read_to_string(&path) else {
-            return;
-        };
-        let Ok(mut stored) = toml::from_str::<Config>(&raw) else {
-            return;
-        };
-        if stored.security.trusted_peers.iter().any(|known| known == fingerprint) {
-            return;
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
         }
-        stored.security.trusted_peers.push(fingerprint.to_string());
+        let mut stored = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| toml::from_str::<Config>(&raw).ok())
+            .unwrap_or_else(|| self.config.clone());
+        update(&mut stored);
         if let Ok(serialized) = toml::to_string(&stored) {
             let _ = std::fs::write(path, serialized);
         }
+    }
+
+    fn resolve_peer_or_fingerprint(&self, target: &str) -> Option<(String, String)> {
+        self.state
+            .peer_fingerprint_by_name(target)
+            .map(|fingerprint| (target.to_string(), fingerprint))
+            .or_else(|| {
+                self.state
+                    .trusted_peer_fingerprints()
+                    .into_iter()
+                    .find(|fingerprint| fingerprint == target)
+                    .map(|fingerprint| (target.to_string(), fingerprint))
+            })
+    }
+
+    fn trust_peer_target(&mut self, target: &str) {
+        let Some((label, fingerprint)) = self.resolve_peer_or_fingerprint(target) else {
+            self.state.add_system_error_message(format!(
+                "unknown peer or fingerprint '{}'. Use /peers or /trust list.",
+                target
+            ));
+            return;
+        };
+        self.state.trust_peer_fingerprint(fingerprint.clone());
+        self.state.set_skill_proposal_trust(&label, true);
+        self.persist_trusted_peer_fingerprint(&fingerprint);
+        self.state.add_system_info_message(format!(
+            "trusted peer {} ({})",
+            label,
+            short_fingerprint(&fingerprint)
+        ));
+    }
+
+    fn untrust_peer_target(&mut self, target: &str) {
+        let Some((label, fingerprint)) = self.resolve_peer_or_fingerprint(target) else {
+            self.state.add_system_error_message(format!(
+                "unknown peer or fingerprint '{}'. Use /trust list.",
+                target
+            ));
+            return;
+        };
+        self.state.untrust_peer_fingerprint(&fingerprint);
+        self.state.set_skill_proposal_trust(&label, false);
+        self.remove_trusted_peer_fingerprint(&fingerprint);
+        self.state.add_system_info_message(format!(
+            "removed trust for {} ({})",
+            label,
+            short_fingerprint(&fingerprint)
+        ));
     }
 
     fn room_list_text(&self) -> String {
@@ -1078,12 +1257,40 @@ impl<'a> Application<'a> {
 
         let mut lines = vec![format!("Connected peers ({}):", self.state.peer_names().len())];
         for peer in self.state.peer_names() {
-            let status = if active_members.iter().any(|member| member == &peer) {
+            let endpoint = self
+                .state
+                .peer_endpoint_by_name(&peer)
+                .expect("peer endpoint should exist for known peer name");
+            let room_status = if active_members.iter().any(|member| member == &peer) {
                 "in room"
             } else {
                 "available"
             };
-            lines.push(format!("  {peer}  [{status}]"));
+            let readiness = match self.state.peer_readiness(endpoint) {
+                PeerReadiness::Ready => "ready",
+                PeerReadiness::Connecting => "connecting",
+            };
+            let fingerprint = self
+                .state
+                .peer_fingerprint(endpoint)
+                .expect("peer fingerprint should exist for known peer");
+            let trust =
+                if self.state.is_trusted_peer(&fingerprint) { "trusted" } else { "untrusted" };
+            lines.push(format!(
+                "  {peer}  [{room_status}, {readiness}, {trust}]  fp={fingerprint}",
+            ));
+        }
+        lines.join("\n")
+    }
+
+    fn trust_list_text(&self) -> String {
+        let fingerprints = self.state.trusted_peer_fingerprints();
+        if fingerprints.is_empty() {
+            return "Trusted peers (0):".into();
+        }
+        let mut lines = vec![format!("Trusted peers ({}):", fingerprints.len())];
+        for fingerprint in fingerprints {
+            lines.push(format!("  {}", fingerprint));
         }
         lines.join("\n")
     }
@@ -1142,7 +1349,13 @@ fn help_text() -> String {
         "/room create @user [--ai <mode>]  Create a room with peers",
         "/room list                        List all rooms",
         "/room switch <room_id>            Switch active room",
+        "",
+        "Peers",
         "/peers                            List connected peers",
+        "/peer connect <host:port>         Connect to a peer directly",
+        "/trust list                       List trusted peer fingerprints",
+        "/trust add <peer|fingerprint>     Trust a peer explicitly",
+        "/trust remove <peer|fingerprint>  Remove stored peer trust",
         "",
         "Skills",
         "/skills               List available skills",
@@ -1187,6 +1400,10 @@ fn ai_frequency_label(frequency: &AiFrequency) -> &'static str {
         AiFrequency::Normal => "normal",
         AiFrequency::High => "high",
     }
+}
+
+fn short_fingerprint(fingerprint: &str) -> &str {
+    fingerprint.get(..12).unwrap_or(fingerprint)
 }
 
 fn render_ai_payload(payload: &AiPayload) -> String {

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -248,7 +248,10 @@ impl<'a> Application<'a> {
                 NetEvent::Connected(_, _) | NetEvent::Accepted(_, _) => {}
                 NetEvent::Message(endpoint, message) => match encoder::decode(&message) {
                     Some(net_message) => self.process_network_message(endpoint, net_message),
-                    None => return Err(anyhow::anyhow!("unknown message received")),
+                    None => self.state.add_system_warn_message(format!(
+                        "ignored incompatible message from {}",
+                        endpoint.addr()
+                    )),
                 },
                 NetEvent::Disconnected(endpoint) => {
                     self.state.disconnected_user(endpoint);
@@ -379,9 +382,18 @@ impl<'a> Application<'a> {
                     ));
                 }
             }
-            NetMessage::RoomCreate(room_id, member_ids, ai_mode) => {
+            NetMessage::RoomCreate(room_id, member_ids) => {
                 if member_ids.iter().any(|member_id| member_id == &self.config.user_name) {
-                    let room = self.state.accept_room(&room_id, &member_ids, ai_mode);
+                    let room = self.state.accept_room(&room_id, &member_ids, None);
+                    self.state.add_system_info_message(format!("joined room {}", room.id));
+                    self.node
+                        .network()
+                        .send(endpoint, self.encoder.encode(NetMessage::RoomJoin(room.id.clone())));
+                }
+            }
+            NetMessage::RoomCreateV2 { room_id, members, ai_mode } => {
+                if members.iter().any(|member_id| member_id == &self.config.user_name) {
+                    let room = self.state.accept_room(&room_id, &members, ai_mode);
                     self.state.add_system_info_message(format!("joined room {}", room.id));
                     self.node
                         .network()
@@ -563,14 +575,16 @@ impl<'a> Application<'a> {
                 for endpoint in self.state.all_user_endpoints() {
                     if let Some(user_name) = self.state.user_name(endpoint) {
                         if peers.iter().any(|peer| peer == user_name) {
-                            self.node.network().send(
-                                endpoint,
-                                self.encoder.encode(NetMessage::RoomCreate(
-                                    room.id.clone(),
-                                    member_ids.clone(),
-                                    ai_mode.clone(),
-                                )),
-                            );
+                            let message = if self.peer_supports_room_create_v2(endpoint) {
+                                NetMessage::RoomCreateV2 {
+                                    room_id: room.id.clone(),
+                                    members: member_ids.clone(),
+                                    ai_mode: ai_mode.clone(),
+                                }
+                            } else {
+                                NetMessage::RoomCreate(room.id.clone(), member_ids.clone())
+                            };
+                            self.node.network().send(endpoint, self.encoder.encode(message));
                         }
                     }
                 }
@@ -663,11 +677,15 @@ impl<'a> Application<'a> {
                 let source = proposal.source_peer.clone();
                 let is_remote = source.is_some();
                 let permission = self.config.security.default_permission_policy();
-                let currently_trusted = source
-                    .as_deref()
-                    .and_then(|peer| self.state.peer_fingerprint_by_name(peer))
-                    .map(|fingerprint| self.state.is_trusted_peer(&fingerprint))
-                    .unwrap_or(proposal.trusted);
+                let currently_trusted = if is_remote {
+                    proposal
+                        .source_fingerprint
+                        .as_deref()
+                        .map(|fingerprint| self.state.is_trusted_peer(fingerprint))
+                        .unwrap_or(false)
+                } else {
+                    proposal.trusted
+                };
                 if is_remote && matches!(permission, DefaultPermission::DenyRemoteExec) {
                     self.state.add_system_error_message(
                         "remote proposals are disabled by security.default_permission".into(),
@@ -790,7 +808,7 @@ impl<'a> Application<'a> {
 
         if self.test_mode {
             match self.runtime.block_on(ai_mediator.request(task, &transcript, &last_messages)) {
-                Ok(payload) => self.record_ai_response(payload, true, None, true),
+                Ok(payload) => self.record_ai_response(payload, true, None, None, true),
                 Err(error) => self.process_ai_failure(error.to_string()),
             }
             return;
@@ -829,7 +847,7 @@ impl<'a> Application<'a> {
                 &transcript,
                 &last_messages,
             )) {
-                Ok(payload) => self.record_ai_response(payload, true, None, true),
+                Ok(payload) => self.record_ai_response(payload, true, None, None, true),
                 Err(error) => self.process_ai_failure(error.to_string()),
             }
             return;
@@ -846,17 +864,17 @@ impl<'a> Application<'a> {
     }
 
     fn process_ai_response(&mut self, payload: AiPayload) {
-        self.record_ai_response(payload, true, None, true);
+        self.record_ai_response(payload, true, None, None, true);
     }
 
     fn process_remote_ai_response(&mut self, endpoint: Endpoint, payload: AiPayload) {
         let source_peer = self.state.user_name(endpoint).cloned();
-        let trusted = self
-            .state
-            .peer_fingerprint(endpoint)
-            .map(|fingerprint| self.state.is_trusted_peer(&fingerprint))
+        let source_fingerprint = self.state.peer_fingerprint(endpoint);
+        let trusted = source_fingerprint
+            .as_deref()
+            .map(|fingerprint| self.state.is_trusted_peer(fingerprint))
             .unwrap_or(false);
-        self.record_ai_response(payload, false, source_peer, trusted);
+        self.record_ai_response(payload, false, source_peer, source_fingerprint, trusted);
     }
 
     fn record_ai_response(
@@ -864,6 +882,7 @@ impl<'a> Application<'a> {
         payload: AiPayload,
         broadcast: bool,
         source_peer: Option<String>,
+        source_fingerprint: Option<String>,
         trusted: bool,
     ) {
         self.state.ai_state = AiState::Idle;
@@ -873,7 +892,12 @@ impl<'a> Application<'a> {
         self.state.abort_handle = None;
         self.state.last_structured_output = payload.structured.clone();
         if let Some(structured) = payload.structured.as_ref() {
-            self.state.set_skill_proposals(&structured.skill_suggestions, source_peer, trusted);
+            self.state.set_skill_proposals_with_fingerprint(
+                &structured.skill_suggestions,
+                source_peer,
+                source_fingerprint,
+                trusted,
+            );
         } else {
             self.state.clear_skill_proposals();
         }
@@ -1006,6 +1030,14 @@ impl<'a> Application<'a> {
         };
         let mut encoder = Encoder::new();
         self.node.network().send(endpoint, encoder.encode(NetMessage::PeerInfo(peer)));
+    }
+
+    fn peer_supports_room_create_v2(&self, endpoint: Endpoint) -> bool {
+        self.state
+            .peers()
+            .get(&endpoint)
+            .map(|peer| version_supports_room_create_v2(&peer.node_version))
+            .unwrap_or(false)
     }
 
     fn announce_presence(&mut self) -> Result<()> {
@@ -1205,6 +1237,7 @@ impl<'a> Application<'a> {
         };
         self.state.trust_peer_fingerprint(fingerprint.clone());
         self.state.set_skill_proposal_trust(&label, true);
+        self.state.set_skill_proposal_trust_by_fingerprint(&fingerprint, true);
         self.persist_trusted_peer_fingerprint(&fingerprint);
         self.state.add_system_info_message(format!(
             "trusted peer {} ({})",
@@ -1223,6 +1256,7 @@ impl<'a> Application<'a> {
         };
         self.state.untrust_peer_fingerprint(&fingerprint);
         self.state.set_skill_proposal_trust(&label, false);
+        self.state.set_skill_proposal_trust_by_fingerprint(&fingerprint, false);
         self.remove_trusted_peer_fingerprint(&fingerprint);
         self.state.add_system_info_message(format!(
             "removed trust for {} ({})",
@@ -1404,6 +1438,21 @@ fn ai_frequency_label(frequency: &AiFrequency) -> &'static str {
 
 fn short_fingerprint(fingerprint: &str) -> &str {
     fingerprint.get(..12).unwrap_or(fingerprint)
+}
+
+fn version_supports_room_create_v2(version: &str) -> bool {
+    parse_semver_tuple(version).map(|parsed| parsed >= (0, 1, 1)).unwrap_or(false)
+}
+
+fn parse_semver_tuple(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
 }
 
 fn render_ai_payload(payload: &AiPayload) -> String {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod ai_cmd;
 pub mod avatar_cmd;
+pub mod peer_cmd;
 pub mod room_cmd;
 pub mod send_file;
 pub mod skill_cmd;
@@ -43,7 +44,11 @@ pub enum AppCommand {
     RoomCreate { peers: Vec<String>, ai_mode: Option<AiMode> },
     RoomList,
     RoomSwitch(String),
+    PeerConnect(String),
     Peers,
+    TrustList,
+    TrustAdd(String),
+    TrustRemove(String),
     Skills,
     Skill { name: String, args: Vec<String> },
     RunProposal(usize),

--- a/src/commands/peer_cmd.rs
+++ b/src/commands/peer_cmd.rs
@@ -1,0 +1,49 @@
+use crate::commands::{AppCommand, Command, ParsedCommand};
+use crate::util::Result;
+
+pub struct PeerCommand;
+pub struct TrustCommand;
+
+impl Command for PeerCommand {
+    fn name(&self) -> &'static str {
+        "peer"
+    }
+
+    fn parse_params(&self, params: Vec<String>) -> Result<ParsedCommand> {
+        match params.first().map(String::as_str) {
+            Some("connect") => {
+                let target = params
+                    .get(1)
+                    .ok_or_else(|| anyhow::anyhow!("usage: /peer connect <host:port>"))?;
+                Ok(ParsedCommand::App(AppCommand::PeerConnect(target.clone())))
+            }
+            Some(other) => Err(anyhow::anyhow!("unknown peer command: {other}")),
+            None => Err(anyhow::anyhow!("usage: /peer connect <host:port>")),
+        }
+    }
+}
+
+impl Command for TrustCommand {
+    fn name(&self) -> &'static str {
+        "trust"
+    }
+
+    fn parse_params(&self, params: Vec<String>) -> Result<ParsedCommand> {
+        match params.first().map(String::as_str).unwrap_or("list") {
+            "list" => Ok(ParsedCommand::App(AppCommand::TrustList)),
+            "add" => {
+                let target = params
+                    .get(1)
+                    .ok_or_else(|| anyhow::anyhow!("usage: /trust add <peer|fingerprint>"))?;
+                Ok(ParsedCommand::App(AppCommand::TrustAdd(target.clone())))
+            }
+            "remove" => {
+                let target = params
+                    .get(1)
+                    .ok_or_else(|| anyhow::anyhow!("usage: /trust remove <peer|fingerprint>"))?;
+                Ok(ParsedCommand::App(AppCommand::TrustRemove(target.clone())))
+            }
+            other => Err(anyhow::anyhow!("unknown trust command: {other}")),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use tui::style::Color;
 
 use crate::util::Result;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Config {
     pub discovery_addr: SocketAddrV4,
     pub tcp_server_port: u16,
@@ -179,6 +179,23 @@ mod tests {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DefaultPermission {
+    ConfirmRequired,
+    TrustedAutoSafe,
+    DenyRemoteExec,
+}
+
+impl DefaultPermission {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ConfirmRequired => "confirm-required",
+            Self::TrustedAutoSafe => "trusted-auto-safe",
+            Self::DenyRemoteExec => "deny-remote-exec",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SecurityConfig {
     pub default_permission: String,
@@ -187,7 +204,20 @@ pub struct SecurityConfig {
 
 impl Default for SecurityConfig {
     fn default() -> Self {
-        Self { default_permission: "confirm-required".into(), trusted_peers: Vec::new() }
+        Self {
+            default_permission: DefaultPermission::ConfirmRequired.as_str().into(),
+            trusted_peers: Vec::new(),
+        }
+    }
+}
+
+impl SecurityConfig {
+    pub fn default_permission_policy(&self) -> DefaultPermission {
+        match self.default_permission.as_str() {
+            "trusted-auto-safe" => DefaultPermission::TrustedAutoSafe,
+            "deny-remote-exec" => DefaultPermission::DenyRemoteExec,
+            _ => DefaultPermission::ConfirmRequired,
+        }
     }
 }
 
@@ -228,7 +258,7 @@ impl Default for LanguageConfig {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Theme {
     pub message_colors: Vec<Color>,
     pub my_user_color: Color,

--- a/src/message.rs
+++ b/src/message.rs
@@ -92,7 +92,8 @@ pub enum NetMessage {
     Stream(Option<(Vec<RGB8>, usize, usize)>),
     AiMessage(AiPayload),
     PeerInfo(PeerInfo),
-    RoomCreate(RoomId, Vec<MemberId>, Option<AiMode>),
+    RoomCreate(RoomId, Vec<MemberId>),
+    RoomCreateV2 { room_id: RoomId, members: Vec<MemberId>, ai_mode: Option<AiMode> },
     RoomJoin(RoomId),
     SkillResult(SkillResultPayload),
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,8 @@
 use rgb::RGB8;
 use serde::{Deserialize, Serialize};
 
+use crate::state::AiMode;
+
 pub type RoomId = String;
 pub type MemberId = String;
 
@@ -90,7 +92,7 @@ pub enum NetMessage {
     Stream(Option<(Vec<RGB8>, usize, usize)>),
     AiMessage(AiPayload),
     PeerInfo(PeerInfo),
-    RoomCreate(RoomId, Vec<MemberId>),
+    RoomCreate(RoomId, Vec<MemberId>, Option<AiMode>),
     RoomJoin(RoomId),
     SkillResult(SkillResultPayload),
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -42,18 +42,26 @@ impl RoomEngine {
         self.active_room_id = Some(room.id);
     }
 
-    pub fn create_remote_room(&mut self, room_id: &str, member_ids: &[String]) -> Room {
+    pub fn create_remote_room(
+        &mut self,
+        room_id: &str,
+        member_ids: &[String],
+        ai_mode: Option<AiMode>,
+    ) -> Room {
         let members = member_ids
             .iter()
             .map(|member_id| {
                 if member_id == "ops-ai" {
-                    Member::remote_ai(member_id.clone())
+                    match ai_mode.clone() {
+                        Some(ai_mode) => Member::ai(member_id.clone(), ai_mode),
+                        None => Member::remote_ai(member_id.clone()),
+                    }
                 } else {
                     Member::human(member_id.clone())
                 }
             })
             .collect::<Vec<_>>();
-        let room = Room { id: room_id.to_string(), members, ai_mode: None };
+        let room = Room { id: room_id.to_string(), members, ai_mode };
         self.insert_room(room.clone());
         room
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -69,6 +69,7 @@ pub struct SkillProposal {
     pub id: usize,
     pub skill_name: String,
     pub source_peer: Option<String>,
+    pub source_fingerprint: Option<String>,
     pub trusted: bool,
 }
 
@@ -319,6 +320,16 @@ impl State {
         source_peer: Option<String>,
         trusted: bool,
     ) {
+        self.set_skill_proposals_with_fingerprint(skill_names, source_peer, None, trusted);
+    }
+
+    pub fn set_skill_proposals_with_fingerprint(
+        &mut self,
+        skill_names: &[String],
+        source_peer: Option<String>,
+        source_fingerprint: Option<String>,
+        trusted: bool,
+    ) {
         self.pending_skill_proposals = skill_names
             .iter()
             .enumerate()
@@ -326,6 +337,7 @@ impl State {
                 id: index + 1,
                 skill_name: skill_name.clone(),
                 source_peer: source_peer.clone(),
+                source_fingerprint: source_fingerprint.clone(),
                 trusted,
             })
             .collect();
@@ -334,6 +346,14 @@ impl State {
     pub fn set_skill_proposal_trust(&mut self, source_peer: &str, trusted: bool) {
         for proposal in &mut self.pending_skill_proposals {
             if proposal.source_peer.as_deref() == Some(source_peer) {
+                proposal.trusted = trusted;
+            }
+        }
+    }
+
+    pub fn set_skill_proposal_trust_by_fingerprint(&mut self, fingerprint: &str, trusted: bool) {
+        for proposal in &mut self.pending_skill_proposals {
+            if proposal.source_fingerprint.as_deref() == Some(fingerprint) {
                 proposal.trusted = trusted;
             }
         }
@@ -375,15 +395,11 @@ impl State {
         if self.lan_users.get(&endpoint).is_some_and(|known| known == user) {
             return;
         }
-        if self
-            .peers
-            .iter()
-            .any(|(known_endpoint, peer)| {
-                *known_endpoint != endpoint
-                    && peer.user_name == user
-                    && peer_readiness(peer) == PeerReadiness::Ready
-            })
-        {
+        if self.peers.iter().any(|(known_endpoint, peer)| {
+            *known_endpoint != endpoint
+                && peer.user_name == user
+                && peer_readiness(peer) == PeerReadiness::Ready
+        }) {
             return;
         }
         self.remove_duplicate_peer_entries(endpoint, user);

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,8 @@ use rgb::RGB8;
 use sha2::{Digest, Sha256};
 use tokio::task::AbortHandle;
 
+use serde::{Deserialize, Serialize};
+
 use crate::avatar::AvatarSize;
 use crate::config::AiProvider;
 use crate::message::{AiPayload, PeerInfo, StructuredOutput};
@@ -30,13 +32,20 @@ pub enum ProgressState {
     Completed,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum AiMode {
     Clerk,
     Listener,
     Moderator,
     Operator,
     Companion,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PeerReadiness {
+    Connecting,
+    Ready,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -274,8 +283,18 @@ impl State {
         self.trusted_peer_fingerprints.insert(fingerprint.into());
     }
 
+    pub fn untrust_peer_fingerprint(&mut self, fingerprint: &str) {
+        self.trusted_peer_fingerprints.remove(fingerprint);
+    }
+
     pub fn is_trusted_peer(&self, fingerprint: &str) -> bool {
         self.trusted_peer_fingerprints.contains(fingerprint)
+    }
+
+    pub fn trusted_peer_fingerprints(&self) -> Vec<String> {
+        let mut fingerprints = self.trusted_peer_fingerprints.iter().cloned().collect::<Vec<_>>();
+        fingerprints.sort();
+        fingerprints
     }
 
     pub fn pending_confirmation(&self) -> Option<&PendingSkillExecution> {
@@ -310,6 +329,14 @@ impl State {
                 trusted,
             })
             .collect();
+    }
+
+    pub fn set_skill_proposal_trust(&mut self, source_peer: &str, trusted: bool) {
+        for proposal in &mut self.pending_skill_proposals {
+            if proposal.source_peer.as_deref() == Some(source_peer) {
+                proposal.trusted = trusted;
+            }
+        }
     }
 
     pub fn clear_skill_proposals(&mut self) {
@@ -348,6 +375,18 @@ impl State {
         if self.lan_users.get(&endpoint).is_some_and(|known| known == user) {
             return;
         }
+        if self
+            .peers
+            .iter()
+            .any(|(known_endpoint, peer)| {
+                *known_endpoint != endpoint
+                    && peer.user_name == user
+                    && peer_readiness(peer) == PeerReadiness::Ready
+            })
+        {
+            return;
+        }
+        self.remove_duplicate_peer_entries(endpoint, user);
         self.lan_users.insert(endpoint, user.into());
         self.peers.entry(endpoint).or_insert_with(|| PeerInfo {
             user_name: user.into(),
@@ -370,6 +409,7 @@ impl State {
     }
 
     pub fn record_peer(&mut self, endpoint: Endpoint, peer: PeerInfo) {
+        self.remove_duplicate_peer_entries(endpoint, &peer.user_name);
         self.peers.insert(endpoint, peer);
     }
 
@@ -382,6 +422,29 @@ impl State {
         peers.sort();
         peers.dedup();
         peers
+    }
+
+    pub fn peer_endpoint_by_name(&self, user_name: &str) -> Option<Endpoint> {
+        self.peers
+            .iter()
+            .filter(|(_, peer)| peer.user_name == user_name)
+            .max_by_key(|(_, peer)| matches!(peer_readiness(peer), PeerReadiness::Ready))
+            .map(|(endpoint, _)| *endpoint)
+    }
+
+    pub fn peer_fingerprint_by_name(&self, user_name: &str) -> Option<String> {
+        self.peer_endpoint_by_name(user_name).and_then(|endpoint| self.peer_fingerprint(endpoint))
+    }
+
+    pub fn peer_readiness(&self, endpoint: Endpoint) -> PeerReadiness {
+        self.peers.get(&endpoint).map(peer_readiness).unwrap_or(PeerReadiness::Connecting)
+    }
+
+    pub fn peer_is_ready(&self, user_name: &str) -> bool {
+        self.peers
+            .iter()
+            .filter(|(_, peer)| peer.user_name == user_name)
+            .any(|(_, peer)| peer_readiness(peer) == PeerReadiness::Ready)
     }
 
     pub fn peer_info_list(&self) -> Vec<(String, String)> {
@@ -410,8 +473,13 @@ impl State {
         self.room_engine.create_room(&self.local_user_name, &refs, ai_mode)
     }
 
-    pub fn accept_room(&mut self, room_id: &str, member_ids: &[String]) -> Room {
-        self.room_engine.create_remote_room(room_id, member_ids)
+    pub fn accept_room(
+        &mut self,
+        room_id: &str,
+        member_ids: &[String],
+        ai_mode: Option<AiMode>,
+    ) -> Room {
+        self.room_engine.create_remote_room(room_id, member_ids, ai_mode)
     }
 
     pub fn room_ids(&self) -> Vec<String> {
@@ -721,6 +789,20 @@ impl State {
             message.rendered_text(),
         )
     }
+
+    fn remove_duplicate_peer_entries(&mut self, endpoint: Endpoint, user: &str) {
+        let duplicate_endpoints = self
+            .lan_users
+            .iter()
+            .filter_map(|(known_endpoint, known_user)| {
+                (*known_endpoint != endpoint && known_user == user).then_some(*known_endpoint)
+            })
+            .collect::<Vec<_>>();
+        for duplicate_endpoint in duplicate_endpoints {
+            self.lan_users.remove(&duplicate_endpoint);
+            self.peers.remove(&duplicate_endpoint);
+        }
+    }
 }
 
 pub fn peer_fingerprint(peer: &PeerInfo) -> String {
@@ -728,6 +810,14 @@ pub fn peer_fingerprint(peer: &PeerInfo) -> String {
     hasher.update(peer.user_name.as_bytes());
     hasher.update(peer.node_version.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+pub fn peer_readiness(peer: &PeerInfo) -> PeerReadiness {
+    if peer.server_port == 0 || peer.node_version == "unknown" {
+        PeerReadiness::Connecting
+    } else {
+        PeerReadiness::Ready
+    }
 }
 
 #[cfg(test)]

--- a/tests/net_message_phase1.rs
+++ b/tests/net_message_phase1.rs
@@ -1,5 +1,19 @@
-use triadchat::message::{NetMessage, PeerInfo, SkillResultPayload};
+use triadchat::message::{AiPayload, Chunk, NetMessage, PeerInfo, SkillResultPayload};
 use triadchat::state::AiMode;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+enum LegacyNetMessage {
+    HelloLan(String, u16),
+    HelloUser(String),
+    UserMessage(String),
+    UserData(String, Chunk),
+    Stream(Option<(Vec<rgb::RGB8>, usize, usize)>),
+    AiMessage(AiPayload),
+    PeerInfo(PeerInfo),
+    RoomCreate(String, Vec<String>),
+    RoomJoin(String),
+    SkillResult(SkillResultPayload),
+}
 
 #[test]
 fn peer_info_round_trips_through_bincode() {
@@ -26,11 +40,13 @@ fn peer_info_round_trips_through_bincode() {
 
 #[test]
 fn room_and_skill_variants_round_trip_through_bincode() {
-    let room_create = NetMessage::RoomCreate(
-        "room-1".into(),
-        vec!["takuro".into(), "tanaka".into()],
-        Some(AiMode::Clerk),
-    );
+    let room_create =
+        NetMessage::RoomCreate("room-1".into(), vec!["takuro".into(), "tanaka".into()]);
+    let room_create_v2 = NetMessage::RoomCreateV2 {
+        room_id: "room-1".into(),
+        members: vec!["takuro".into(), "tanaka".into()],
+        ai_mode: Some(AiMode::Clerk),
+    };
     let room_join = NetMessage::RoomJoin("room-1".into());
     let skill_done = NetMessage::SkillResult(SkillResultPayload {
         skill_name: "review-auth".into(),
@@ -38,15 +54,26 @@ fn room_and_skill_variants_round_trip_through_bincode() {
         success: true,
     });
 
-    for message in [room_create, room_join, skill_done] {
+    for message in [room_create, room_create_v2, room_join, skill_done] {
         let encoded = bincode::serialize(&message).expect("message should serialize");
         let decoded: NetMessage =
             bincode::deserialize(&encoded).expect("message should deserialize");
 
         match (message, decoded) {
             (
-                NetMessage::RoomCreate(expected_id, expected_members, expected_mode),
-                NetMessage::RoomCreate(id, members, mode),
+                NetMessage::RoomCreate(expected_id, expected_members),
+                NetMessage::RoomCreate(id, members),
+            ) => {
+                assert_eq!(id, expected_id);
+                assert_eq!(members, expected_members);
+            }
+            (
+                NetMessage::RoomCreateV2 {
+                    room_id: expected_id,
+                    members: expected_members,
+                    ai_mode: expected_mode,
+                },
+                NetMessage::RoomCreateV2 { room_id: id, members, ai_mode: mode },
             ) => {
                 assert_eq!(id, expected_id);
                 assert_eq!(members, expected_members);
@@ -62,5 +89,23 @@ fn room_and_skill_variants_round_trip_through_bincode() {
             }
             pair => panic!("unexpected round-trip pair: {:?}", pair),
         }
+    }
+}
+
+#[test]
+fn legacy_room_create_bytes_remain_decodable() {
+    let legacy =
+        LegacyNetMessage::RoomCreate("room-1".into(), vec!["takuro".into(), "tanaka".into()]);
+
+    let encoded = bincode::serialize(&legacy).expect("legacy message should serialize");
+    let decoded: NetMessage =
+        bincode::deserialize(&encoded).expect("new decoder should accept legacy bytes");
+
+    match decoded {
+        NetMessage::RoomCreate(room_id, members) => {
+            assert_eq!(room_id, "room-1");
+            assert_eq!(members, vec!["takuro", "tanaka"]);
+        }
+        other => panic!("unexpected decoded message: {:?}", other),
     }
 }

--- a/tests/net_message_phase1.rs
+++ b/tests/net_message_phase1.rs
@@ -1,4 +1,5 @@
 use triadchat::message::{NetMessage, PeerInfo, SkillResultPayload};
+use triadchat::state::AiMode;
 
 #[test]
 fn peer_info_round_trips_through_bincode() {
@@ -25,8 +26,11 @@ fn peer_info_round_trips_through_bincode() {
 
 #[test]
 fn room_and_skill_variants_round_trip_through_bincode() {
-    let room_create =
-        NetMessage::RoomCreate("room-1".into(), vec!["takuro".into(), "tanaka".into()]);
+    let room_create = NetMessage::RoomCreate(
+        "room-1".into(),
+        vec!["takuro".into(), "tanaka".into()],
+        Some(AiMode::Clerk),
+    );
     let room_join = NetMessage::RoomJoin("room-1".into());
     let skill_done = NetMessage::SkillResult(SkillResultPayload {
         skill_name: "review-auth".into(),
@@ -41,11 +45,12 @@ fn room_and_skill_variants_round_trip_through_bincode() {
 
         match (message, decoded) {
             (
-                NetMessage::RoomCreate(expected_id, expected_members),
-                NetMessage::RoomCreate(id, members),
+                NetMessage::RoomCreate(expected_id, expected_members, expected_mode),
+                NetMessage::RoomCreate(id, members, mode),
             ) => {
                 assert_eq!(id, expected_id);
                 assert_eq!(members, expected_members);
+                assert_eq!(mode, expected_mode);
             }
             (NetMessage::RoomJoin(expected_id), NetMessage::RoomJoin(id)) => {
                 assert_eq!(id, expected_id);

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -50,10 +50,8 @@ fn peer_handshake_and_room_create_propagates() {
     let mut tanaka = Application::new_for_test(&tanaka_config).unwrap();
 
     takuro.start_network_for_test().unwrap();
-    std::thread::sleep(Duration::from_millis(100));
     tanaka.start_network_for_test().unwrap();
-    takuro.announce_presence_for_test().unwrap();
-    tanaka.announce_presence_for_test().unwrap();
+    takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
         left.state().peers().len() == 1
@@ -154,10 +152,8 @@ fn room_switch_rejects_zero_index() {
     let mut tanaka = Application::new_for_test(&tanaka_config).unwrap();
 
     takuro.start_network_for_test().unwrap();
-    std::thread::sleep(Duration::from_millis(100));
     tanaka.start_network_for_test().unwrap();
-    takuro.announce_presence_for_test().unwrap();
-    tanaka.announce_presence_for_test().unwrap();
+    takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
         left.state().peers().len() == 1
@@ -298,4 +294,92 @@ description: Review auth
         .collect::<Vec<_>>()
         .join("\n");
     assert!(transcript.contains("review-auth executed"));
+}
+
+#[test]
+fn trust_remove_by_fingerprint_blocks_disconnected_peer_proposals() {
+    let workspace = tempfile::TempDir::new().unwrap();
+    let skills_dir = workspace.path().join(".claude/skills/review-auth");
+    std::fs::create_dir_all(&skills_dir).unwrap();
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        r#"---
+name: review-auth
+invoke: auto_safe
+risk: low
+description: Review auth
+---
+"#,
+    )
+    .unwrap();
+
+    let script_path = workspace.path().join("mock-claude.sh");
+    std::fs::write(&script_path, "#!/bin/sh\nprintf 'review-auth executed'\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let discovery_port = 43000 + (rand::random::<u16>() % 1000);
+    let mut takuro_config = test_config("takuro", discovery_port);
+    takuro_config.ai.command = Some(script_path.display().to_string());
+    takuro_config.security.default_permission = "confirm-required".into();
+    let mut tanaka_config = test_config("tanaka", discovery_port);
+    tanaka_config.ai.command = Some(script_path.display().to_string());
+    let mut takuro =
+        Application::new_for_test_in_workspace(&takuro_config, workspace.path()).unwrap();
+    let mut tanaka =
+        Application::new_for_test_in_workspace(&tanaka_config, workspace.path()).unwrap();
+
+    takuro.start_network_for_test().unwrap();
+    tanaka.start_network_for_test().unwrap();
+    takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().peers().len() == 1 && right.state().peers().len() == 1
+    });
+
+    let fingerprint = takuro.state().peer_fingerprint_by_name("tanaka").unwrap();
+    let endpoint = tanaka.state().all_user_endpoints()[0];
+    let payload = AiPayload {
+        text: "review-auth suggested".into(),
+        intent: AiIntent::SkillSuggest,
+        structured: Some(StructuredOutput {
+            todos: Vec::new(),
+            decisions: Vec::new(),
+            skill_suggestions: vec!["review-auth".into()],
+            raw_text: None,
+        }),
+    };
+    let mut encoded = Vec::new();
+    bincode::serialize_into(&mut encoded, &NetMessage::AiMessage(payload)).unwrap();
+    tanaka.node_handler().network().send(endpoint, &encoded);
+    takuro.process_next_event_with_timeout_for_test(Duration::from_secs(1)).unwrap();
+
+    takuro.handle_input_line_for_test("/trust add tanaka").unwrap();
+    drop(tanaka);
+
+    let disconnect_deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < disconnect_deadline && !takuro.state().peers().is_empty() {
+        let _ = takuro.process_next_event_with_timeout_for_test(Duration::from_millis(50));
+    }
+    assert!(takuro.state().peers().is_empty());
+
+    takuro.handle_input_line_for_test(&format!("/trust remove {fingerprint}")).unwrap();
+    takuro.handle_input_line_for_test("/run 1").unwrap();
+
+    let transcript = takuro
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(transcript.contains("removed trust for"));
+    assert!(transcript.contains("permission denied: proposal 1 came from untrusted peer tanaka"));
+    assert!(takuro.state().pending_confirmation().is_none());
+    assert!(!transcript.contains("review-auth executed"));
 }

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -2,6 +2,8 @@ use std::time::{Duration, Instant};
 
 use triadchat::application::Application;
 use triadchat::config::Config;
+use triadchat::message::{AiIntent, AiPayload, NetMessage, StructuredOutput};
+use triadchat::state::AiMode;
 
 fn test_config(user_name: &str, discovery_port: u16) -> Config {
     Config {
@@ -54,7 +56,10 @@ fn peer_handshake_and_room_create_propagates() {
     tanaka.announce_presence_for_test().unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
-        left.state().peers().len() == 1 && right.state().peers().len() == 1
+        left.state().peers().len() == 1
+            && right.state().peers().len() == 1
+            && left.state().peer_is_ready("tanaka")
+            && right.state().peer_is_ready("takuro")
     });
 
     takuro.handle_input_line_for_test("/room create @tanaka --ai clerk").unwrap();
@@ -68,6 +73,8 @@ fn peer_handshake_and_room_create_propagates() {
 
     let takuro_room = &takuro.state().rooms()[0];
     assert!(takuro_room.members.iter().any(|member| member.id == "ops-ai"));
+    assert_eq!(takuro_room.ai_mode, Some(AiMode::Clerk));
+    assert_eq!(tanaka.state().rooms()[0].ai_mode, Some(AiMode::Clerk));
     assert_eq!(
         tanaka.state().peers().values().next().map(|peer| peer.user_name.as_str()),
         Some("takuro")
@@ -127,8 +134,8 @@ fn room_and_peer_commands_show_richer_metadata() {
         .join("\n");
 
     assert!(rendered.contains("Connected peers (2):"), "{rendered}");
-    assert!(rendered.contains("tanaka  [in room]"), "{rendered}");
-    assert!(rendered.contains("sato  [available]"), "{rendered}");
+    assert!(rendered.contains("tanaka  [in room, ready, untrusted]"), "{rendered}");
+    assert!(rendered.contains("sato  [available, ready, untrusted]"), "{rendered}");
     assert!(rendered.contains("Rooms (1):"), "{rendered}");
     assert!(rendered.contains("1"), "{rendered}");
     assert!(rendered.contains("room-1"), "{rendered}");
@@ -153,7 +160,10 @@ fn room_switch_rejects_zero_index() {
     tanaka.announce_presence_for_test().unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
-        left.state().peers().len() == 1 && right.state().peers().len() == 1
+        left.state().peers().len() == 1
+            && right.state().peers().len() == 1
+            && left.state().peer_is_ready("tanaka")
+            && right.state().peer_is_ready("takuro")
     });
 
     takuro.handle_input_line_for_test("/room create @tanaka --ai clerk").unwrap();
@@ -173,4 +183,119 @@ fn room_switch_rejects_zero_index() {
 
     assert_eq!(rendered, "unknown room id: 0");
     assert_eq!(takuro.state().active_room_id(), Some(active_room.as_str()));
+}
+
+#[test]
+fn peer_connect_command_bootstraps_room_creation_without_multicast() {
+    let discovery_port = 41000 + (rand::random::<u16>() % 1000);
+    let takuro_config = test_config("takuro", discovery_port);
+    let tanaka_config = test_config("tanaka", discovery_port);
+    let mut takuro = Application::new_for_test(&takuro_config).unwrap();
+    let mut tanaka = Application::new_for_test(&tanaka_config).unwrap();
+
+    takuro.start_network_for_test().unwrap();
+    tanaka.start_network_for_test().unwrap();
+
+    takuro
+        .handle_input_line_for_test(&format!(
+            "/peer connect 127.0.0.1:{}",
+            tanaka.local_server_port_for_test().unwrap()
+        ))
+        .unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().peers().len() == 1 && right.state().peers().len() == 1
+    });
+
+    takuro.handle_input_line_for_test("/room create @tanaka --ai clerk").unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().rooms().len() == 1
+            && right.state().rooms().len() == 1
+            && left.state().active_room_id() == right.state().active_room_id()
+    });
+
+    assert_eq!(tanaka.state().rooms()[0].ai_mode, Some(AiMode::Clerk));
+}
+
+#[test]
+fn remote_skill_proposals_require_explicit_trust_before_run() {
+    let workspace = tempfile::TempDir::new().unwrap();
+    let skills_dir = workspace.path().join(".claude/skills/review-auth");
+    std::fs::create_dir_all(&skills_dir).unwrap();
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        r#"---
+name: review-auth
+invoke: auto_safe
+risk: low
+description: Review auth
+---
+"#,
+    )
+    .unwrap();
+
+    let script_path = workspace.path().join("mock-claude.sh");
+    std::fs::write(&script_path, "#!/bin/sh\nprintf 'review-auth executed'\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let discovery_port = 42000 + (rand::random::<u16>() % 1000);
+    let mut takuro_config = test_config("takuro", discovery_port);
+    takuro_config.ai.command = Some(script_path.display().to_string());
+    takuro_config.security.default_permission = "confirm-required".into();
+    let mut tanaka_config = test_config("tanaka", discovery_port);
+    tanaka_config.ai.command = Some(script_path.display().to_string());
+    let mut takuro =
+        Application::new_for_test_in_workspace(&takuro_config, workspace.path()).unwrap();
+    let mut tanaka =
+        Application::new_for_test_in_workspace(&tanaka_config, workspace.path()).unwrap();
+
+    takuro.start_network_for_test().unwrap();
+    tanaka.start_network_for_test().unwrap();
+    takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
+
+    pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
+        left.state().peers().len() == 1 && right.state().peers().len() == 1
+    });
+
+    let endpoint = tanaka.state().all_user_endpoints()[0];
+    let payload = AiPayload {
+        text: "review-auth suggested".into(),
+        intent: AiIntent::SkillSuggest,
+        structured: Some(StructuredOutput {
+            todos: Vec::new(),
+            decisions: Vec::new(),
+            skill_suggestions: vec!["review-auth".into()],
+            raw_text: None,
+        }),
+    };
+    let mut encoded = Vec::new();
+    bincode::serialize_into(&mut encoded, &NetMessage::AiMessage(payload)).unwrap();
+    tanaka.node_handler().network().send(endpoint, &encoded);
+    takuro.process_next_event_with_timeout_for_test(Duration::from_secs(1)).unwrap();
+
+    takuro.handle_input_line_for_test("/run 1").unwrap();
+    let rendered = takuro.state().messages().last().unwrap().rendered_text();
+    assert!(rendered.contains("Use /trust add tanaka"));
+
+    takuro.handle_input_line_for_test("/trust add tanaka").unwrap();
+    takuro.handle_input_line_for_test("/run 1").unwrap();
+    assert!(takuro.state().pending_confirmation().is_some());
+
+    takuro.handle_confirmation_input_for_test('y').unwrap();
+
+    let transcript = takuro
+        .state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(transcript.contains("review-auth executed"));
 }

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -97,7 +97,14 @@ fn room_and_peer_commands_show_richer_metadata() {
 
     let deadline = Instant::now() + Duration::from_secs(3);
     while Instant::now() < deadline {
-        if takuro.state().peers().len() == 2 && tanaka.state().peers().len() == 1 {
+        if takuro.state().peers().len() == 2
+            && tanaka.state().peers().len() == 1
+            && sato.state().peers().len() == 1
+            && takuro.state().peer_is_ready("tanaka")
+            && takuro.state().peer_is_ready("sato")
+            && tanaka.state().peer_is_ready("takuro")
+            && sato.state().peer_is_ready("takuro")
+        {
             break;
         }
         let _ = takuro.process_next_event_with_timeout_for_test(Duration::from_millis(50));
@@ -200,7 +207,10 @@ fn peer_connect_command_bootstraps_room_creation_without_multicast() {
         .unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
-        left.state().peers().len() == 1 && right.state().peers().len() == 1
+        left.state().peers().len() == 1
+            && right.state().peers().len() == 1
+            && left.state().peer_is_ready("tanaka")
+            && right.state().peer_is_ready("takuro")
     });
 
     takuro.handle_input_line_for_test("/room create @tanaka --ai clerk").unwrap();
@@ -257,7 +267,10 @@ description: Review auth
     takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
-        left.state().peers().len() == 1 && right.state().peers().len() == 1
+        left.state().peers().len() == 1
+            && right.state().peers().len() == 1
+            && left.state().peer_is_ready("tanaka")
+            && right.state().peer_is_ready("takuro")
     });
 
     let endpoint = tanaka.state().all_user_endpoints()[0];
@@ -339,7 +352,10 @@ description: Review auth
     takuro.connect_peer_for_test(tanaka.local_server_port_for_test().unwrap()).unwrap();
 
     pump_until(&mut takuro, &mut tanaka, Duration::from_secs(3), |left, right| {
-        left.state().peers().len() == 1 && right.state().peers().len() == 1
+        left.state().peers().len() == 1
+            && right.state().peers().len() == 1
+            && left.state().peer_is_ready("tanaka")
+            && right.state().peer_is_ready("takuro")
     });
 
     let fingerprint = takuro.state().peer_fingerprint_by_name("tanaka").unwrap();

--- a/tests/phase0_commands_e2e.rs
+++ b/tests/phase0_commands_e2e.rs
@@ -150,6 +150,7 @@ fn help_command_groups_commands_with_descriptions() {
     assert!(rendered.contains("AI"));
     assert!(rendered.contains("Summary"));
     assert!(rendered.contains("Rooms"));
+    assert!(rendered.contains("Peers"));
     assert!(rendered.contains("Skills"));
     assert!(rendered.contains("Avatar"));
     assert!(rendered.contains("Files"));
@@ -161,6 +162,8 @@ fn help_command_groups_commands_with_descriptions() {
     assert!(rendered.contains("/ai mode <clerk|listener|moderator|operator|companion>"));
     assert!(rendered.contains("/room switch <room_id>"));
     assert!(rendered.contains("Switch active room"));
+    assert!(rendered.contains("/peer connect <host:port>"));
+    assert!(rendered.contains("/trust add <peer|fingerprint>"));
     assert!(rendered.contains("/skill <name> [args]"));
     assert!(rendered.contains("Run a skill"));
     assert!(rendered.contains("/send <file>"));

--- a/tests/room_engine.rs
+++ b/tests/room_engine.rs
@@ -33,11 +33,15 @@ fn room_engine_lists_room_members_in_stable_order() {
 }
 
 #[test]
-fn remote_room_does_not_invent_ai_mode() {
+fn remote_room_preserves_ai_mode_from_creator() {
     let mut engine = RoomEngine::default();
-    let room = engine.create_remote_room("room-1", &["takuro".into(), "ops-ai".into()]);
+    let room = engine.create_remote_room(
+        "room-1",
+        &["takuro".into(), "ops-ai".into()],
+        Some(AiMode::Clerk),
+    );
 
-    assert_eq!(room.ai_mode, None);
+    assert_eq!(room.ai_mode, Some(AiMode::Clerk));
     assert_eq!(room.members[1].kind, MemberKind::Ai);
-    assert_eq!(room.members[1].ai_mode, None);
+    assert_eq!(room.members[1].ai_mode, Some(AiMode::Clerk));
 }


### PR DESCRIPTION
## Summary
- add explicit peer trust management and enforce `security.default_permission` for remote proposals
- propagate room AI mode over `RoomCreate` and preserve it on remote members
- stabilize LAN discovery with retries, readiness checks, and `/peer connect <host:port>` fallback

## Verification
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --test phase0_commands_e2e --test phase1_commands_e2e --test network_integration`

Closes #28
Closes #29
Closes #30