### PR TITLE
Fix AI mode parsing duplication

### DIFF
--- a/src/ai/classifier.rs
+++ b/src/ai/classifier.rs
@@ -20,10 +20,6 @@ impl MessageClass {
     }
 }
 
-pub fn classify_message(input: &str) -> MessageClass {
-    MessageClass::classify(input)
-}
-
 pub fn contains_decision_marker(input: &str) -> bool {
     let normalized = input.to_lowercase();
     normalized.contains("決定")

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -540,10 +540,8 @@ impl<'a> Application<'a> {
             },
             AppCommand::SetAiMode(mode) => {
                 self.state.ai_mode = mode;
-                self.state.add_system_info_message(format!(
-                    "AI mode set to {}",
-                    ai_mode_label(&self.state.ai_mode)
-                ));
+                self.state
+                    .add_system_info_message(format!("AI mode set to {}", self.state.ai_mode));
             }
             AppCommand::SetAiQuiet(enabled) => {
                 self.state.ai_mode = if enabled { AiMode::Listener } else { AiMode::Clerk };
@@ -1395,7 +1393,7 @@ fn describe_room(room: &Room) -> String {
         "{} [{}] — AI: {}",
         room.id,
         human_member_names(room).join(", "),
-        room.ai_mode.as_ref().map(ai_mode_label).unwrap_or("off")
+        room.ai_mode.as_ref().map(AiMode::to_string).unwrap_or_else(|| "off".to_string())
     )
 }
 
@@ -1404,7 +1402,7 @@ fn describe_room_list_entry(room: &Room) -> String {
         "{} [{}] mode: {}",
         room.id,
         human_member_names(room).join(", "),
-        room.ai_mode.as_ref().map(ai_mode_label).unwrap_or("off")
+        room.ai_mode.as_ref().map(AiMode::to_string).unwrap_or_else(|| "off".to_string())
     )
 }
 
@@ -1502,16 +1500,6 @@ impl Drop for Application<'_> {
             handle.abort();
         }
         self.node.stop();
-    }
-}
-
-fn ai_mode_label(mode: &AiMode) -> &'static str {
-    match mode {
-        AiMode::Clerk => "clerk",
-        AiMode::Listener => "listener",
-        AiMode::Moderator => "moderator",
-        AiMode::Operator => "operator",
-        AiMode::Companion => "companion",
     }
 }
 

--- a/src/commands/ai_cmd.rs
+++ b/src/commands/ai_cmd.rs
@@ -69,15 +69,6 @@ mod tests {
     }
 
     #[test]
-    fn ai_mode_from_str_accepts_all_known_modes() {
-        assert!("clerk".parse::<AiMode>().is_ok());
-        assert!("listener".parse::<AiMode>().is_ok());
-        assert!("moderator".parse::<AiMode>().is_ok());
-        assert!("operator".parse::<AiMode>().is_ok());
-        assert!("companion".parse::<AiMode>().is_ok());
-    }
-
-    #[test]
     fn parse_params_error_describes_available_modes() {
         let error = AiCommand
             .parse_params(vec!["wat".into()])

--- a/src/commands/ai_cmd.rs
+++ b/src/commands/ai_cmd.rs
@@ -13,7 +13,11 @@ impl Command for AiCommand {
         let subcommand = params.first().map(String::as_str).unwrap_or("help");
         match subcommand {
             "mode" => {
-                let mode = parse_mode(params.get(1).map(String::as_str).unwrap_or("clerk"))?;
+                let mode = params
+                    .get(1)
+                    .map(String::as_str)
+                    .unwrap_or("clerk")
+                    .parse::<AiMode>()?;
                 Ok(ParsedCommand::App(AppCommand::SetAiMode(mode)))
             }
             "quiet" => {
@@ -36,17 +40,6 @@ impl Command for AiCommand {
     }
 }
 
-fn parse_mode(value: &str) -> Result<AiMode> {
-    match value {
-        "clerk" => Ok(AiMode::Clerk),
-        "listener" => Ok(AiMode::Listener),
-        "moderator" => Ok(AiMode::Moderator),
-        "operator" => Ok(AiMode::Operator),
-        "companion" => Ok(AiMode::Companion),
-        other => Err(anyhow::anyhow!("unknown ai mode: {other}")),
-    }
-}
-
 fn parse_frequency(value: &str) -> Result<AiFrequency> {
     match value {
         "low" => Ok(AiFrequency::Low),
@@ -62,22 +55,26 @@ mod tests {
     use crate::commands::Command;
 
     #[test]
-    fn parse_mode_companion_returns_companion() {
-        assert_eq!(parse_mode("companion").unwrap(), AiMode::Companion);
+    fn parse_params_companion_mode_returns_companion() {
+        let parsed = AiCommand
+            .parse_params(vec!["mode".into(), "companion".into()])
+            .expect("companion is a valid AI mode");
+
+        assert!(matches!(parsed, ParsedCommand::App(AppCommand::SetAiMode(AiMode::Companion))));
     }
 
     #[test]
-    fn parse_mode_unknown_returns_error() {
-        assert!(parse_mode("unknown_mode").is_err());
+    fn parse_params_unknown_mode_returns_error() {
+        assert!(AiCommand.parse_params(vec!["mode".into(), "unknown_mode".into()]).is_err());
     }
 
     #[test]
-    fn parse_mode_all_known_modes() {
-        assert!(parse_mode("clerk").is_ok());
-        assert!(parse_mode("listener").is_ok());
-        assert!(parse_mode("moderator").is_ok());
-        assert!(parse_mode("operator").is_ok());
-        assert!(parse_mode("companion").is_ok());
+    fn ai_mode_from_str_accepts_all_known_modes() {
+        assert!("clerk".parse::<AiMode>().is_ok());
+        assert!("listener".parse::<AiMode>().is_ok());
+        assert!("moderator".parse::<AiMode>().is_ok());
+        assert!("operator".parse::<AiMode>().is_ok());
+        assert!("companion".parse::<AiMode>().is_ok());
     }
 
     #[test]

--- a/src/commands/room_cmd.rs
+++ b/src/commands/room_cmd.rs
@@ -80,4 +80,16 @@ mod tests {
             ParsedCommand::App(AppCommand::RoomCreate { ai_mode: Some(AiMode::Companion), .. })
         ));
     }
+
+    #[test]
+    fn room_create_unknown_ai_mode_returns_error() {
+        let result = RoomCommand.parse_params(vec![
+            "create".into(),
+            "@user".into(),
+            "--ai".into(),
+            "unknown_mode".into(),
+        ]);
+
+        assert!(result.is_err());
+    }
 }

--- a/src/commands/room_cmd.rs
+++ b/src/commands/room_cmd.rs
@@ -26,7 +26,7 @@ impl Command for RoomCommand {
                             let value = params
                                 .get(index + 1)
                                 .ok_or_else(|| anyhow::anyhow!("missing value for --ai"))?;
-                            ai_mode = Some(parse_mode(value)?);
+                            ai_mode = Some(value.parse::<AiMode>()?);
                             index += 1;
                         }
                         other => return Err(anyhow::anyhow!("unknown room argument: {other}")),
@@ -64,12 +64,20 @@ impl Command for PeersCommand {
     }
 }
 
-fn parse_mode(value: &str) -> Result<AiMode> {
-    match value {
-        "clerk" => Ok(AiMode::Clerk),
-        "listener" => Ok(AiMode::Listener),
-        "moderator" => Ok(AiMode::Moderator),
-        "operator" => Ok(AiMode::Operator),
-        other => Err(anyhow::anyhow!("unknown ai mode: {other}")),
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{Command, ParsedCommand};
+
+    #[test]
+    fn room_create_accepts_companion_ai_mode() {
+        let parsed = RoomCommand
+            .parse_params(vec!["create".into(), "@user".into(), "--ai".into(), "companion".into()])
+            .expect("companion is a valid AI mode");
+
+        assert!(matches!(
+            parsed,
+            ParsedCommand::App(AppCommand::RoomCreate { ai_mode: Some(AiMode::Companion), .. })
+        ));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -57,6 +57,19 @@ impl std::str::FromStr for AiMode {
     }
 }
 
+impl std::fmt::Display for AiMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::Clerk => "clerk",
+            Self::Listener => "listener",
+            Self::Moderator => "moderator",
+            Self::Operator => "operator",
+            Self::Companion => "companion",
+        };
+        f.write_str(value)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PeerReadiness {
     Connecting,
@@ -1029,6 +1042,30 @@ mod tests {
 
     fn submit(state: &mut State) -> Option<String> {
         state.reset_input()
+    }
+
+    #[test]
+    fn ai_mode_from_str_accepts_all_known_modes() {
+        assert!("clerk".parse::<AiMode>().is_ok());
+        assert!("listener".parse::<AiMode>().is_ok());
+        assert!("moderator".parse::<AiMode>().is_ok());
+        assert!("operator".parse::<AiMode>().is_ok());
+        assert!("companion".parse::<AiMode>().is_ok());
+    }
+
+    #[test]
+    fn ai_mode_display_round_trips_through_from_str() {
+        for mode in [
+            AiMode::Clerk,
+            AiMode::Listener,
+            AiMode::Moderator,
+            AiMode::Operator,
+            AiMode::Companion,
+        ] {
+            let rendered = mode.to_string();
+
+            assert_eq!(rendered.parse::<AiMode>().expect("display value should parse"), mode);
+        }
     }
 
     // --- reset_input pushes to history ---

--- a/src/state.rs
+++ b/src/state.rs
@@ -42,6 +42,21 @@ pub enum AiMode {
     Companion,
 }
 
+impl std::str::FromStr for AiMode {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "clerk" => Ok(Self::Clerk),
+            "listener" => Ok(Self::Listener),
+            "moderator" => Ok(Self::Moderator),
+            "operator" => Ok(Self::Operator),
+            "companion" => Ok(Self::Companion),
+            other => Err(anyhow::anyhow!("unknown ai mode: {other}")),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PeerReadiness {
     Connecting,


### PR DESCRIPTION
## Summary
- Add shared `FromStr` parsing for `AiMode`, including `companion`
- Replace duplicated command-local AI mode parsers in `/ai` and `/room` commands
- Remove the unused `classify_message` wrapper

Closes #33

## Tests
- `cargo test room_create_accepts_companion_ai_mode` (expected red before implementation)
- `cargo test --lib`
- `cargo test`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`