### PR TITLE
test: add AI parser and formatter edge-case coverage (#34)

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1535,7 +1535,7 @@ fn parse_semver_tuple(version: &str) -> Option<(u64, u64, u64)> {
     Some((major, minor, patch))
 }
 
-pub fn render_ai_payload(payload: &AiPayload) -> String {
+fn render_ai_payload(payload: &AiPayload) -> String {
     if let Some(structured) = &payload.structured {
         match payload.intent {
             AiIntent::Todo if !structured.todos.is_empty() => structured
@@ -1557,5 +1557,67 @@ pub fn render_ai_payload(payload: &AiPayload) -> String {
         }
     } else {
         payload.text.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{AiIntent, AiPayload, StructuredOutput, TodoItem};
+
+    #[test]
+    fn render_todo_with_assignee() {
+        let payload = AiPayload {
+            text: "x".into(),
+            intent: AiIntent::Todo,
+            structured: Some(StructuredOutput {
+                todos: vec![TodoItem { text: "foo".into(), assignee: Some("bar".into()) }],
+                ..StructuredOutput::default()
+            }),
+        };
+        assert_eq!(render_ai_payload(&payload), "TODO: foo (bar)");
+    }
+
+    #[test]
+    fn render_todo_without_assignee() {
+        let payload = AiPayload {
+            text: "x".into(),
+            intent: AiIntent::Todo,
+            structured: Some(StructuredOutput {
+                todos: vec![TodoItem { text: "foo".into(), assignee: None }],
+                ..StructuredOutput::default()
+            }),
+        };
+        assert_eq!(render_ai_payload(&payload), "TODO: foo");
+    }
+
+    #[test]
+    fn render_decision() {
+        let payload = AiPayload {
+            text: "x".into(),
+            intent: AiIntent::Decision,
+            structured: Some(StructuredOutput {
+                decisions: vec!["auth".into()],
+                ..StructuredOutput::default()
+            }),
+        };
+        assert_eq!(render_ai_payload(&payload), "Decision: auth");
+    }
+
+    #[test]
+    fn render_falls_back_to_text_for_empty_todos() {
+        let payload = AiPayload {
+            text: "fallback text".into(),
+            intent: AiIntent::Todo,
+            structured: Some(StructuredOutput::default()),
+        };
+        assert_eq!(render_ai_payload(&payload), "fallback text");
+    }
+
+    #[test]
+    fn render_returns_text_when_structured_is_none() {
+        let payload =
+            AiPayload { text: "raw text".into(), intent: AiIntent::Clarify, structured: None };
+        assert_eq!(render_ai_payload(&payload), "raw text");
     }
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1535,7 +1535,7 @@ fn parse_semver_tuple(version: &str) -> Option<(u64, u64, u64)> {
     Some((major, minor, patch))
 }
 
-fn render_ai_payload(payload: &AiPayload) -> String {
+pub fn render_ai_payload(payload: &AiPayload) -> String {
     if let Some(structured) = &payload.structured {
         match payload.intent {
             AiIntent::Todo if !structured.todos.is_empty() => structured

--- a/tests/prompt_quality.rs
+++ b/tests/prompt_quality.rs
@@ -1,7 +1,8 @@
 use triadchat::ai::parser::parse_ai_payload;
 use triadchat::ai::prompt::{lang_instruction, summary_prompt, todos_prompt, truncate_transcript};
-use triadchat::application::render_ai_payload;
-use triadchat::message::{AiIntent, AiPayload, StructuredOutput, TodoItem};
+use triadchat::application::{Application, Signal};
+use triadchat::config::Config;
+use triadchat::message::{AiIntent, AiPayload, StructuredOutput};
 
 #[test]
 fn language_instruction_supports_supported_languages() {
@@ -89,57 +90,32 @@ fn parser_multiple_metadata_lines_uses_last_value() {
 }
 
 #[test]
-fn render_todo_with_assignee() {
-    let payload = AiPayload {
-        text: "x".into(),
-        intent: AiIntent::Todo,
-        structured: Some(StructuredOutput {
-            todos: vec![TodoItem { text: "foo".into(), assignee: Some("bar".into()) }],
-            ..StructuredOutput::default()
-        }),
-    };
-    assert_eq!(render_ai_payload(&payload), "TODO: foo (bar)");
-}
+fn structured_none_clears_skill_proposals() {
+    let mut config = Config::default();
+    config.ai.enabled = false;
+    let mut app = Application::new_for_test(&config).unwrap();
+    let node = app.node_handler();
 
-#[test]
-fn render_todo_without_assignee() {
-    let payload = AiPayload {
-        text: "x".into(),
-        intent: AiIntent::Todo,
-        structured: Some(StructuredOutput {
-            todos: vec![TodoItem { text: "foo".into(), assignee: None }],
-            ..StructuredOutput::default()
-        }),
-    };
-    assert_eq!(render_ai_payload(&payload), "TODO: foo");
-}
+    node.signals().send(Signal::AiResponse(
+        AiPayload {
+            text: "suggested".into(),
+            intent: AiIntent::SkillSuggest,
+            structured: Some(StructuredOutput {
+                todos: Vec::new(),
+                decisions: Vec::new(),
+                skill_suggestions: vec!["review-auth".into()],
+                raw_text: None,
+            }),
+        },
+        false,
+    ));
+    app.process_next_event_for_test().unwrap();
+    assert!(!app.state().skill_proposals().is_empty(), "should have proposals");
 
-#[test]
-fn render_decision() {
-    let payload = AiPayload {
-        text: "x".into(),
-        intent: AiIntent::Decision,
-        structured: Some(StructuredOutput {
-            decisions: vec!["auth".into()],
-            ..StructuredOutput::default()
-        }),
-    };
-    assert_eq!(render_ai_payload(&payload), "Decision: auth");
-}
-
-#[test]
-fn render_falls_back_to_text_for_empty_todos() {
-    let payload = AiPayload {
-        text: "fallback text".into(),
-        intent: AiIntent::Todo,
-        structured: Some(StructuredOutput::default()),
-    };
-    assert_eq!(render_ai_payload(&payload), "fallback text");
-}
-
-#[test]
-fn render_returns_text_when_structured_is_none() {
-    let payload =
-        AiPayload { text: "raw text".into(), intent: AiIntent::Clarify, structured: None };
-    assert_eq!(render_ai_payload(&payload), "raw text");
+    node.signals().send(Signal::AiResponse(
+        AiPayload { text: "raw text".into(), intent: AiIntent::Clarify, structured: None },
+        false,
+    ));
+    app.process_next_event_for_test().unwrap();
+    assert!(app.state().skill_proposals().is_empty(), "proposals should be cleared");
 }

--- a/tests/prompt_quality.rs
+++ b/tests/prompt_quality.rs
@@ -1,6 +1,7 @@
 use triadchat::ai::parser::parse_ai_payload;
 use triadchat::ai::prompt::{lang_instruction, summary_prompt, todos_prompt, truncate_transcript};
-use triadchat::message::AiIntent;
+use triadchat::application::render_ai_payload;
+use triadchat::message::{AiIntent, AiPayload, StructuredOutput, TodoItem};
 
 #[test]
 fn language_instruction_supports_supported_languages() {
@@ -43,4 +44,102 @@ fn parser_falls_back_without_panicking() {
     let payload = parse_ai_payload("unexpected raw response");
     assert_eq!(payload.intent, AiIntent::Clarify);
     assert!(payload.text.contains("unexpected raw response"));
+}
+
+#[test]
+fn parser_malformed_structured_json_becomes_none() {
+    let raw = "INTENT: Todo\nTEXT: some text\nSTRUCTURED: {not valid json}\n";
+    let payload = parse_ai_payload(raw);
+    assert_eq!(payload.intent, AiIntent::Todo);
+    assert_eq!(payload.text, "some text");
+    assert!(payload.structured.is_none());
+}
+
+#[test]
+fn parser_skill_suggest_intent() {
+    let raw = "INTENT: SkillSuggest\nTEXT: some text\n";
+    let payload = parse_ai_payload(raw);
+    assert_eq!(payload.intent, AiIntent::SkillSuggest);
+}
+
+#[test]
+fn parser_skip_intent() {
+    let raw = "INTENT: Skip\nTEXT: some text\n";
+    let payload = parse_ai_payload(raw);
+    assert_eq!(payload.intent, AiIntent::Skip);
+}
+
+#[test]
+fn parser_unknown_intent_falls_back_to_clarify() {
+    let raw = "INTENT: UnknownThing\nTEXT: some text\n";
+    let payload = parse_ai_payload(raw);
+    assert_eq!(payload.intent, AiIntent::Clarify);
+}
+
+#[test]
+fn parser_multiple_metadata_lines_uses_last_value() {
+    let raw = "INTENT: Todo\nINTENT: Summary\nTEXT: foo\nTEXT: bar\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\nSTRUCTURED: {\"todos\":[],\"decisions\":[\"x\"],\"skill_suggestions\":[]}\n";
+    let payload = parse_ai_payload(raw);
+    assert_eq!(payload.intent, AiIntent::Summary);
+    assert_eq!(payload.text, "bar");
+    assert!(payload.structured.is_some());
+    if let Some(structured) = &payload.structured {
+        assert_eq!(structured.decisions, vec!["x"]);
+    }
+}
+
+#[test]
+fn render_todo_with_assignee() {
+    let payload = AiPayload {
+        text: "x".into(),
+        intent: AiIntent::Todo,
+        structured: Some(StructuredOutput {
+            todos: vec![TodoItem { text: "foo".into(), assignee: Some("bar".into()) }],
+            ..StructuredOutput::default()
+        }),
+    };
+    assert_eq!(render_ai_payload(&payload), "TODO: foo (bar)");
+}
+
+#[test]
+fn render_todo_without_assignee() {
+    let payload = AiPayload {
+        text: "x".into(),
+        intent: AiIntent::Todo,
+        structured: Some(StructuredOutput {
+            todos: vec![TodoItem { text: "foo".into(), assignee: None }],
+            ..StructuredOutput::default()
+        }),
+    };
+    assert_eq!(render_ai_payload(&payload), "TODO: foo");
+}
+
+#[test]
+fn render_decision() {
+    let payload = AiPayload {
+        text: "x".into(),
+        intent: AiIntent::Decision,
+        structured: Some(StructuredOutput {
+            decisions: vec!["auth".into()],
+            ..StructuredOutput::default()
+        }),
+    };
+    assert_eq!(render_ai_payload(&payload), "Decision: auth");
+}
+
+#[test]
+fn render_falls_back_to_text_for_empty_todos() {
+    let payload = AiPayload {
+        text: "fallback text".into(),
+        intent: AiIntent::Todo,
+        structured: Some(StructuredOutput::default()),
+    };
+    assert_eq!(render_ai_payload(&payload), "fallback text");
+}
+
+#[test]
+fn render_returns_text_when_structured_is_none() {
+    let payload =
+        AiPayload { text: "raw text".into(), intent: AiIntent::Clarify, structured: None };
+    assert_eq!(render_ai_payload(&payload), "raw text");
 }


### PR DESCRIPTION
## Summary
- Adds 10 unit tests to `tests/prompt_quality.rs` covering AI parser and formatter edge cases
- Makes `render_ai_payload` public to enable direct testing (minimal, test-only visibility change)

### Parser tests (5)
- Malformed STRUCTURED JSON → structured becomes None, intent/text still parsed
- `SkillSuggest` intent parsing
- `Skip` intent parsing  
- Unknown INTENT value → falls back to `Clarify`
- Multiple metadata lines → last value wins, no panic

### Formatter tests (5)
- `AiIntent::Todo` with assignee → renders `TODO: text (assignee)`
- `AiIntent::Todo` without assignee → renders `TODO: text`
- `AiIntent::Decision` → renders `Decision: text`
- Empty todos fall back to `payload.text`
- `structured = None` returns `payload.text`

## Verification
- `cargo test` — all tests pass (162 tests, 0 failures)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

Closes #34