### PR TITLE
Replace low-signal avatar/layout tests with invariants

### DIFF
--- a/src/avatar/loader.rs
+++ b/src/avatar/loader.rs
@@ -93,10 +93,7 @@ impl AvatarManager {
 
 #[cfg(feature = "avatar-ffi")]
 fn is_dylib(path: &std::path::Path) -> bool {
-    match path.extension().and_then(|e| e.to_str()) {
-        Some("so") | Some("dylib") | Some("dll") => true,
-        _ => false,
-    }
+    matches!(path.extension().and_then(|e| e.to_str()), Some("so") | Some("dylib") | Some("dll"))
 }
 
 /// Wraps a loaded `libloading::Library` as an `AvatarPlugin`.

--- a/tests/avatar_builtin.rs
+++ b/tests/avatar_builtin.rs
@@ -1,210 +1,77 @@
+use triadchat::avatar::builtin::all_builtins;
 use triadchat::avatar::{AvatarSize, AvatarState};
-use triadchat::avatar::builtin::{ai_default, claude, human_default, neko, robot_guardian};
 
-// ─── AvatarSize auto-selection ────────────────────────────────────────────────
-
-#[test]
-fn compact_size_selected_for_narrow_terminals() {
-    assert_eq!(AvatarSize::for_width(79), AvatarSize::Compact);
-    assert_eq!(AvatarSize::for_width(0), AvatarSize::Compact);
-}
+// ─── Builtin render invariants ────────────────────────────────────────────────
 
 #[test]
-fn normal_size_selected_for_standard_width() {
-    assert_eq!(AvatarSize::for_width(80), AvatarSize::Normal);
-    assert_eq!(AvatarSize::for_width(120), AvatarSize::Normal);
-}
+fn compact_render_is_single_visible_line_for_every_builtin_state() {
+    for plugin in all_builtins() {
+        for state in all_states() {
+            let rendered = plugin.render(state.clone(), AvatarSize::Compact);
 
-// ─── human_default ────────────────────────────────────────────────────────────
-
-#[test]
-fn human_default_returns_non_empty_for_all_states_and_sizes() {
-    let plugin = human_default();
-    for state in all_states() {
-        for size in all_sizes() {
-            let rendered = plugin.render(state.clone(), size);
-            assert!(!rendered.is_empty(), "human_default rendered empty for {state:?} {size:?}");
+            assert_eq!(
+                rendered.len(),
+                1,
+                "{} compact render must fit the single-line peers panel for {state:?}",
+                plugin.preset_name()
+            );
+            assert!(
+                !render_text(&rendered).trim().is_empty(),
+                "{} compact render must remain visible for {state:?}",
+                plugin.preset_name()
+            );
         }
     }
 }
 
 #[test]
-fn human_default_compact_is_shorter_than_normal() {
-    let plugin = human_default();
-    let compact = plugin.render(AvatarState::Online, AvatarSize::Compact);
-    let normal = plugin.render(AvatarState::Online, AvatarSize::Normal);
-    assert!(
-        compact.len() <= normal.len(),
-        "Compact ({} lines) should be <= Normal ({} lines)",
-        compact.len(),
-        normal.len()
-    );
-}
+fn active_ai_states_change_every_builtin_avatar() {
+    for plugin in all_builtins() {
+        let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
+        let thinking = plugin.render(AvatarState::Thinking, AvatarSize::Normal);
+        let acting = plugin.render(AvatarState::Acting, AvatarSize::Normal);
 
-#[test]
-fn human_default_preset_name_is_human_default() {
-    assert_eq!(human_default().preset_name(), "human_default");
-}
-
-// ─── ai_default ───────────────────────────────────────────────────────────────
-
-#[test]
-fn ai_default_returns_non_empty_for_all_states_and_sizes() {
-    let plugin = ai_default();
-    for state in all_states() {
-        for size in all_sizes() {
-            let rendered = plugin.render(state.clone(), size);
-            assert!(!rendered.is_empty(), "ai_default rendered empty for {state:?} {size:?}");
-        }
+        assert_ne!(
+            idle,
+            thinking,
+            "{} should visually change while thinking",
+            plugin.preset_name()
+        );
+        assert_ne!(idle, acting, "{} should visually change while acting", plugin.preset_name());
     }
 }
 
 #[test]
-fn ai_default_thinking_differs_from_idle() {
-    let plugin = ai_default();
-    let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
-    let thinking = plugin.render(AvatarState::Thinking, AvatarSize::Normal);
-    assert_ne!(idle, thinking, "idle and thinking should produce different renders");
-}
+fn presence_states_change_human_facing_builtin_avatars() {
+    for plugin in all_builtins() {
+        let online = plugin.render(AvatarState::Online, AvatarSize::Compact);
+        let away = plugin.render(AvatarState::Away, AvatarSize::Compact);
+        let offline = plugin.render(AvatarState::Offline, AvatarSize::Compact);
 
-#[test]
-fn ai_default_acting_differs_from_idle() {
-    let plugin = ai_default();
-    let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
-    let acting = plugin.render(AvatarState::Acting, AvatarSize::Normal);
-    assert_ne!(idle, acting, "idle and acting should produce different renders");
-}
-
-#[test]
-fn ai_default_preset_name_is_ai_default() {
-    assert_eq!(ai_default().preset_name(), "ai_default");
-}
-
-// ─── robot_guardian ───────────────────────────────────────────────────────────
-
-#[test]
-fn robot_guardian_returns_non_empty_for_all_states_and_sizes() {
-    let plugin = robot_guardian();
-    for state in all_states() {
-        for size in all_sizes() {
-            let rendered = plugin.render(state.clone(), size);
-            assert!(!rendered.is_empty(), "robot_guardian rendered empty for {state:?} {size:?}");
-        }
+        assert_ne!(
+            render_text(&online),
+            render_text(&away),
+            "{} compact render should distinguish away from online",
+            plugin.preset_name()
+        );
+        assert_ne!(
+            render_text(&online),
+            render_text(&offline),
+            "{} compact render should distinguish offline from online",
+            plugin.preset_name()
+        );
     }
-}
-
-#[test]
-fn robot_guardian_state_changes_are_reflected() {
-    let plugin = robot_guardian();
-    let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
-    let acting = plugin.render(AvatarState::Acting, AvatarSize::Normal);
-    assert_ne!(idle, acting, "robot_guardian idle vs acting should differ");
-}
-
-#[test]
-fn robot_guardian_preset_name_is_robot_guardian() {
-    assert_eq!(robot_guardian().preset_name(), "robot_guardian");
-}
-
-// ─── AvatarPlugin trait object safety ────────────────────────────────────────
-
-#[test]
-fn all_builtins_can_be_used_as_trait_objects() {
-    let plugins: Vec<Box<dyn triadchat::avatar::AvatarPlugin>> =
-        vec![human_default(), ai_default(), robot_guardian()];
-    for plugin in &plugins {
-        let output = plugin.render(AvatarState::Idle, AvatarSize::Normal);
-        assert!(!output.is_empty(), "trait object render for '{}' was empty", plugin.preset_name());
-    }
-}
-
-// ─── claude ───────────────────────────────────────────────────────────────────
-
-#[test]
-fn claude_preset_name_is_claude() {
-    assert_eq!(claude().preset_name(), "claude");
-}
-
-#[test]
-fn claude_returns_non_empty_for_all_states_and_sizes() {
-    let plugin = claude();
-    for state in all_states() {
-        for size in all_sizes() {
-            let rendered = plugin.render(state.clone(), size);
-            assert!(!rendered.is_empty(), "claude rendered empty for {state:?} {size:?}");
-        }
-    }
-}
-
-#[test]
-fn claude_compact_is_single_line_for_all_states() {
-    let plugin = claude();
-    for state in all_states() {
-        let rendered = plugin.render(state.clone(), AvatarSize::Compact);
-        assert!(rendered.len() <= 1, "claude compact must be at most one line for {state:?}");
-    }
-}
-
-#[test]
-fn claude_thinking_differs_from_idle() {
-    let plugin = claude();
-    let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
-    let thinking = plugin.render(AvatarState::Thinking, AvatarSize::Normal);
-    assert_ne!(idle, thinking);
-}
-
-#[test]
-fn claude_acting_differs_from_idle() {
-    let plugin = claude();
-    let idle = plugin.render(AvatarState::Idle, AvatarSize::Normal);
-    let acting = plugin.render(AvatarState::Acting, AvatarSize::Normal);
-    assert_ne!(idle, acting);
-}
-
-// ─── neko ─────────────────────────────────────────────────────────────────────
-
-#[test]
-fn neko_preset_name_is_neko() {
-    assert_eq!(neko().preset_name(), "neko");
-}
-
-#[test]
-fn neko_returns_non_empty_for_all_states_and_sizes() {
-    let plugin = neko();
-    for state in all_states() {
-        for size in all_sizes() {
-            let rendered = plugin.render(state.clone(), size);
-            assert!(!rendered.is_empty(), "neko rendered empty for {state:?} {size:?}");
-        }
-    }
-}
-
-#[test]
-fn neko_compact_is_single_line_for_all_states() {
-    let plugin = neko();
-    for state in all_states() {
-        let rendered = plugin.render(state.clone(), AvatarSize::Compact);
-        assert!(rendered.len() <= 1, "neko compact must be at most one line for {state:?}");
-    }
-}
-
-#[test]
-fn neko_online_differs_from_offline() {
-    let plugin = neko();
-    let online = plugin.render(AvatarState::Online, AvatarSize::Normal);
-    let offline = plugin.render(AvatarState::Offline, AvatarSize::Normal);
-    assert_ne!(online, offline);
-}
-
-#[test]
-fn neko_busy_differs_from_online() {
-    let plugin = neko();
-    let online = plugin.render(AvatarState::Online, AvatarSize::Normal);
-    let busy = plugin.render(AvatarState::Busy, AvatarSize::Normal);
-    assert_ne!(online, busy);
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn render_text(rendered: &[tui::text::Spans<'static>]) -> String {
+    rendered
+        .iter()
+        .map(|line| line.0.iter().map(|span| span.content.as_ref()).collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 fn all_states() -> Vec<AvatarState> {
     vec![
@@ -218,8 +85,4 @@ fn all_states() -> Vec<AvatarState> {
         AvatarState::Busy,
         AvatarState::Away,
     ]
-}
-
-fn all_sizes() -> Vec<AvatarSize> {
-    vec![AvatarSize::Compact, AvatarSize::Normal, AvatarSize::Expressive]
 }

--- a/tests/avatar_plugin.rs
+++ b/tests/avatar_plugin.rs
@@ -1,68 +1,46 @@
 use std::path::PathBuf;
 
+use triadchat::avatar::builtin::ai_default;
 use triadchat::avatar::loader::AvatarManager;
 use triadchat::avatar::{AvatarSize, AvatarState};
 
 // ─── Builtin fallback (no external dylibs) ───────────────────────────────────
 
 #[test]
-fn avatar_manager_loads_builtins_when_no_plugin_dir() {
-    let non_existent = PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz");
-    let manager = AvatarManager::new(non_existent);
+fn avatar_manager_registers_all_builtin_fallback_presets() {
+    let manager = manager_without_plugin_dir();
     let presets = manager.list_all_presets();
-    assert!(!presets.is_empty(), "builtin presets must always be available");
-}
 
-#[test]
-fn avatar_manager_includes_builtin_human_default() {
-    let manager = AvatarManager::new(PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz"));
-    let presets = manager.list_all_presets();
-    assert!(
-        presets.iter().any(|p| p == "human_default"),
-        "human_default must be a builtin preset; got: {presets:?}"
-    );
-}
-
-#[test]
-fn avatar_manager_includes_builtin_ai_default() {
-    let manager = AvatarManager::new(PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz"));
-    let presets = manager.list_all_presets();
-    assert!(presets.iter().any(|p| p == "ai_default"));
-}
-
-#[test]
-fn avatar_manager_includes_builtin_robot_guardian() {
-    let manager = AvatarManager::new(PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz"));
-    let presets = manager.list_all_presets();
-    assert!(presets.iter().any(|p| p == "robot_guardian"));
+    for expected in ["human_default", "ai_default", "robot_guardian", "claude", "neko"] {
+        assert!(presets.iter().any(|preset| preset == expected), "missing builtin {expected}");
+    }
 }
 
 // ─── render() falls back to builtins ─────────────────────────────────────────
 
 #[test]
-fn render_known_preset_returns_non_empty() {
-    let manager = AvatarManager::new(PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz"));
+fn render_known_builtin_matches_direct_builtin_render() {
+    let manager = manager_without_plugin_dir();
     let rendered = manager.render("ai_default", AvatarState::Idle, AvatarSize::Normal);
-    assert!(!rendered.is_empty());
+    let direct = ai_default().render(AvatarState::Idle, AvatarSize::Normal);
+
+    assert_eq!(rendered, direct);
 }
 
 #[test]
 fn render_unknown_preset_falls_back_to_ai_default() {
-    let manager = AvatarManager::new(PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz"));
-    let rendered = manager.render("no_such_preset", AvatarState::Idle, AvatarSize::Normal);
-    assert!(!rendered.is_empty(), "fallback must always produce output");
-}
+    let manager = manager_without_plugin_dir();
 
-// ─── list_all_presets deduplicates ───────────────────────────────────────────
+    for (state, size) in [
+        (AvatarState::Thinking, AvatarSize::Compact),
+        (AvatarState::Acting, AvatarSize::Normal),
+        (AvatarState::Idle, AvatarSize::Expressive),
+    ] {
+        let rendered = manager.render("no_such_preset", state.clone(), size);
+        let fallback = ai_default().render(state, size);
 
-#[test]
-fn list_all_presets_has_no_duplicates() {
-    let manager = AvatarManager::new(PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz"));
-    let mut presets = manager.list_all_presets();
-    presets.sort_unstable();
-    let original_len = presets.len();
-    presets.dedup();
-    assert_eq!(presets.len(), original_len, "preset list must not contain duplicates");
+        assert_eq!(rendered, fallback, "unknown preset must exactly match ai_default fallback");
+    }
 }
 
 // ─── empty dir is tolerated (no panic) ──────────────────────────────────────
@@ -72,4 +50,8 @@ fn avatar_manager_with_empty_plugin_dir_does_not_panic() {
     let tmp = tempfile::tempdir().unwrap();
     let manager = AvatarManager::new(tmp.path().to_path_buf());
     assert!(!manager.list_all_presets().is_empty());
+}
+
+fn manager_without_plugin_dir() -> AvatarManager {
+    AvatarManager::new(PathBuf::from("/tmp/triadchat-test-no-such-avatars-dir-xyz"))
 }

--- a/tests/phase0_basics.rs
+++ b/tests/phase0_basics.rs
@@ -1,11 +1,16 @@
 use std::path::Path;
 
-use triadchat::commands::CommandManager;
+use triadchat::commands::{AppCommand, CommandManager, ParsedCommand};
 use triadchat::config::{Config, LanguageConfig};
 
 #[test]
-fn command_prefix_is_slash() {
-    assert_eq!(CommandManager::COMMAND_PREFIX, "/");
+fn slash_prefixed_help_parses_but_plain_text_does_not() {
+    let manager = CommandManager::default();
+
+    let parsed = manager.find_command("/help").expect("/help should be recognized").unwrap();
+    assert!(matches!(parsed, ParsedCommand::App(AppCommand::Help)));
+    assert!(manager.find_command("help").is_none());
+    assert!(manager.find_command("hello /help").is_none());
 }
 
 #[test]

--- a/tests/ui_layout.rs
+++ b/tests/ui_layout.rs
@@ -1,65 +1,15 @@
-use triadchat::ui::layout::{left_right_constraints, right_column_constraints, should_show_side_panels};
-
-// ─── Left/right horizontal constraints ───────────────────────────────────────
-
-#[test]
-fn left_right_constraints_have_two_panes() {
-    let constraints = left_right_constraints();
-    assert_eq!(constraints.len(), 2);
-}
+use triadchat::avatar::AvatarSize;
+use triadchat::ui::layout::should_show_side_panels;
 
 #[test]
-fn peers_panel_width_is_18() {
-    use tui::layout::Constraint;
-    let constraints = left_right_constraints();
-    assert_eq!(constraints[0], Constraint::Length(18));
-}
-
-#[test]
-fn right_column_uses_min_constraint() {
-    use tui::layout::Constraint;
-    let constraints = left_right_constraints();
-    assert_eq!(constraints[1], Constraint::Min(0));
-}
-
-// ─── Right column vertical constraints ───────────────────────────────────────
-
-#[test]
-fn right_column_constraints_have_two_panes() {
-    let constraints = right_column_constraints();
-    assert_eq!(constraints.len(), 2);
-}
-
-#[test]
-fn chat_uses_min_constraint() {
-    use tui::layout::Constraint;
-    let constraints = right_column_constraints();
-    assert_eq!(constraints[0], Constraint::Min(0));
-}
-
-#[test]
-fn status_panel_height_is_8() {
-    use tui::layout::Constraint;
-    let constraints = right_column_constraints();
-    assert_eq!(constraints[1], Constraint::Length(8));
-}
-
-// ─── Side panel visibility ────────────────────────────────────────────────────
-
-#[test]
-fn side_panels_hidden_for_narrow_terminal() {
-    assert!(!should_show_side_panels(79));
-    assert!(!should_show_side_panels(0));
-}
-
-#[test]
-fn side_panels_shown_for_wide_terminal() {
-    assert!(should_show_side_panels(80));
-    assert!(should_show_side_panels(120));
-    assert!(should_show_side_panels(200));
-}
-
-#[test]
-fn boundary_at_exactly_80_columns_shows_panels() {
-    assert!(should_show_side_panels(80));
+fn side_panel_visibility_and_avatar_size_change_at_same_boundary() {
+    for (cols, should_show_panels, avatar_size) in [
+        (0, false, AvatarSize::Compact),
+        (79, false, AvatarSize::Compact),
+        (80, true, AvatarSize::Normal),
+        (120, true, AvatarSize::Normal),
+    ] {
+        assert_eq!(should_show_side_panels(cols), should_show_panels);
+        assert_eq!(AvatarSize::for_width(cols), avatar_size);
+    }
 }


### PR DESCRIPTION
## Summary
- consolidate builtin avatar tests around compact single-line rendering and state-change invariants
- strengthen AvatarManager fallback tests to compare exact ai_default renders
- replace layout and slash-prefix smoke checks with boundary/parser behavior
- fix avatar FFI extension detection clippy warning found during verification

Closes #39

## Verification
- cargo build
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test avatar_builtin --test avatar_plugin --test ui_layout --test phase0_basics --test room_list_panel
- cargo test --test phase0_commands_e2e
- cargo test --test phase1_commands_e2e
- cargo test --test network_integration
- cargo test --test send_file
- cargo test