### PR TITLE
Refactor test helpers and cleanup imports

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -1,8 +1,8 @@
-use crate::state::{State};
+use crate::state::State;
 
-use message_io::network::{NetworkController};
+use message_io::network::NetworkController;
 
-use std::time::{Duration};
+use std::time::Duration;
 
 pub enum Processing {
     Completed,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -11,6 +11,7 @@ use message_io::network::{Endpoint, Transport};
 use message_io::node::{
     self, NodeHandler, NodeTask, StoredNetEvent as NetEvent, StoredNodeEvent as NodeEvent,
 };
+use tracing::warn;
 
 use crate::action::{Action, Processing};
 use crate::ai::trigger::{contains_ops_ai_mention, should_intervene, TriggerConfig};
@@ -1450,10 +1451,11 @@ impl<'a> Application<'a> {
 
         let mut lines = vec![format!("Connected peers ({}):", self.state.peer_names().len())];
         for peer in self.state.peer_names() {
-            let endpoint = self
-                .state
-                .peer_endpoint_by_name(&peer)
-                .expect("peer endpoint should exist for known peer name");
+            let Some(endpoint) = self.state.peer_endpoint_by_name(&peer) else {
+                warn!("peer listed without endpoint: {peer}");
+                lines.push(format!("  {peer}  [unavailable]"));
+                continue;
+            };
             let room_status = if active_members.iter().any(|member| member == &peer) {
                 "in room"
             } else {
@@ -1463,10 +1465,12 @@ impl<'a> Application<'a> {
                 PeerReadiness::Ready => "ready",
                 PeerReadiness::Connecting => "connecting",
             };
-            let fingerprint = self
-                .state
-                .peer_fingerprint(endpoint)
-                .expect("peer fingerprint should exist for known peer");
+            let Some(fingerprint) = self.state.peer_fingerprint(endpoint) else {
+                warn!("peer endpoint has no fingerprint: {peer}");
+                lines
+                    .push(format!("  {peer}  [{room_status}, {readiness}, untrusted]  fp=unknown"));
+                continue;
+            };
             let trust =
                 if self.state.is_trusted_peer(&fingerprint) { "trusted" } else { "untrusted" };
             lines.push(format!(
@@ -1643,22 +1647,28 @@ fn load_art_dictionary(
 
 fn expand_shortcodes(input: &str, art_dict: &HashMap<String, String>) -> String {
     let mut result = String::with_capacity(input.len());
-    let mut chars = input.char_indices().peekable();
-    while let Some((_, ch)) = chars.next() {
-        if ch == '[' {
-            let remaining: String = chars.clone().map(|(_, c)| c).collect();
-            if let Some((key, _)) = remaining.split_once(']') {
-                if let Some(art) = art_dict.get(key) {
-                    result.push_str(art);
-                    for _ in 0..=key.chars().count() {
-                        chars.next();
-                    }
-                    continue;
-                }
+    let mut cursor = 0;
+
+    while let Some(open_rel) = input[cursor..].find('[') {
+        let open = cursor + open_rel;
+        result.push_str(&input[cursor..open]);
+
+        let key_start = open + '['.len_utf8();
+        if let Some(close_rel) = input[key_start..].find(']') {
+            let close = key_start + close_rel;
+            let key = &input[key_start..close];
+            if let Some(art) = art_dict.get(key) {
+                result.push_str(art);
+                cursor = close + ']'.len_utf8();
+                continue;
             }
         }
-        result.push(ch);
+
+        result.push('[');
+        cursor = key_start;
     }
+
+    result.push_str(&input[cursor..]);
     result
 }
 
@@ -1765,5 +1775,25 @@ mod tests {
         let payload =
             AiPayload { text: "raw text".into(), intent: AiIntent::Clarify, structured: None };
         assert_eq!(render_ai_payload(&payload), "raw text");
+    }
+
+    #[test]
+    fn expand_shortcodes_replaces_known_codes_without_losing_unicode() {
+        let mut art_dict = HashMap::new();
+        art_dict.insert("猫".to_string(), "Neko".to_string());
+        art_dict.insert("wave".to_string(), "o/".to_string());
+
+        assert_eq!(expand_shortcodes("[猫] says [wave]", &art_dict), "Neko says o/");
+    }
+
+    #[test]
+    fn expand_shortcodes_leaves_unknown_or_unclosed_codes_intact() {
+        let mut art_dict = HashMap::new();
+        art_dict.insert("ok".to_string(), "OK".to_string());
+
+        assert_eq!(
+            expand_shortcodes("[nope] [ok] [unterminated", &art_dict),
+            "[nope] OK [unterminated"
+        );
     }
 }

--- a/src/commands/art_cmd.rs
+++ b/src/commands/art_cmd.rs
@@ -1,12 +1,6 @@
 use crate::commands::{AppCommand, Command, ParsedCommand};
 use crate::util::Result;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ArtCommandKind {
-    List,
-    Reload,
-}
-
 pub struct ArtCommand;
 
 impl Command for ArtCommand {

--- a/src/commands/send_file.rs
+++ b/src/commands/send_file.rs
@@ -1,16 +1,16 @@
 use crate::action::{Action, Processing};
 use crate::commands::{Command, ParsedCommand};
-use crate::state::{State};
-use crate::message::{NetMessage, Chunk};
-use crate::util::{Result, Reportable};
-use crate::encoder::{Encoder};
+use crate::encoder::Encoder;
+use crate::message::{Chunk, NetMessage};
+use crate::state::State;
+use crate::util::{Reportable, Result};
 
 use std::collections::HashSet;
-use message_io::network::{NetworkController, Endpoint};
+use message_io::network::{Endpoint, NetworkController};
 
-use std::path::{Path};
-use std::io::{Read};
-use std::time::{Duration};
+use std::io::Read;
+use std::path::Path;
+use std::time::Duration;
 
 pub struct SendFileCommand;
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -9,6 +9,7 @@ use crossterm::ExecutableCommand;
 
 use tui::backend::CrosstermBackend;
 use tui::Terminal;
+use tracing::warn;
 
 use std::io::Write;
 
@@ -39,11 +40,12 @@ impl<W: Write> Renderer<W> {
 
 impl<W: Write> Drop for Renderer<W> {
     fn drop(&mut self) {
-        self.terminal
-            .backend_mut()
-            .execute(terminal::LeaveAlternateScreen)
-            .expect("Could not execute to stdout");
-        terminal::disable_raw_mode().expect("Terminal doesn't support to disable raw mode");
+        if let Err(error) = self.terminal.backend_mut().execute(terminal::LeaveAlternateScreen) {
+            warn!("failed to leave alternate screen: {error}");
+        }
+        if let Err(error) = terminal::disable_raw_mode() {
+            warn!("failed to disable raw mode: {error}");
+        }
         if std::thread::panicking() {
             eprintln!(
                 "triadchat panicked, redirect stderr to a file to inspect the failure, for example: triadchat 2> triadchat.log",

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,14 +1,14 @@
 use crate::avatar::loader::AvatarManager;
 use crate::config::Config;
 use crate::state::State;
-use crate::ui::{self};
+use crate::ui;
 use crate::util::Result;
 
-use crossterm::terminal::{self};
-use crossterm::{ExecutableCommand};
+use crossterm::terminal;
+use crossterm::ExecutableCommand;
 
-use tui::{Terminal};
-use tui::backend::{CrosstermBackend};
+use tui::backend::CrosstermBackend;
+use tui::Terminal;
 
 use std::io::Write;
 

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -5,6 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::message::RoomId;
 use crate::state::AiMode;
+use tracing::warn;
 
 pub use member::{Member, MemberKind};
 
@@ -31,7 +32,13 @@ impl RoomEngine {
         }
 
         self.next_room_number += 1;
-        let ts_ms = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
+        let ts_ms = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_millis(),
+            Err(error) => {
+                warn!("system clock is before UNIX_EPOCH while creating room id: {error}");
+                0
+            }
+        };
         let id = format!("{owner}-{ts_ms}-{}", self.next_room_number);
         let room = Room { id, members, ai_mode };
         self.active_room_id = Some(room.id.clone());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,36 @@
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use triadchat::application::Application;
+use triadchat::config::{AiConfig, Config};
+
+pub fn write_executable_script(dir: impl AsRef<Path>, name: &str, contents: &str) -> PathBuf {
+    let path = dir.as_ref().join(name);
+    std::fs::write(&path, contents).unwrap();
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(0o755);
+    }
+    std::fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+pub fn rendered_messages(app: &Application<'_>) -> String {
+    app.state()
+        .messages()
+        .iter()
+        .map(|message| message.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn config_with_ai_script(script: impl AsRef<Path>, user_name: &str) -> Config {
+    Config {
+        user_name: user_name.to_string(),
+        ai: AiConfig { command: Some(script.as_ref().display().to_string()), ..Default::default() },
+        ..Default::default()
+    }
+}

--- a/tests/network_integration.rs
+++ b/tests/network_integration.rs
@@ -5,6 +5,10 @@ use triadchat::config::Config;
 use triadchat::message::{AiIntent, AiPayload, NetMessage, StructuredOutput};
 use triadchat::state::AiMode;
 
+mod common;
+
+use common::{rendered_messages, write_executable_script};
+
 fn test_config(user_name: &str, discovery_port: u16) -> Config {
     Config {
         user_name: user_name.to_string(),
@@ -134,13 +138,7 @@ fn room_and_peer_commands_show_richer_metadata() {
     takuro.handle_input_line_for_test("/room list").unwrap();
     takuro.handle_input_line_for_test("/room switch 1").unwrap();
 
-    let rendered = takuro
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&takuro);
 
     assert!(rendered.contains("Connected peers (2):"), "{rendered}");
     assert!(rendered.contains("tanaka  [in room, ready, untrusted]"), "{rendered}");
@@ -249,15 +247,11 @@ description: Review auth
     )
     .unwrap();
 
-    let script_path = workspace.path().join("mock-claude.sh");
-    std::fs::write(&script_path, "#!/bin/sh\nprintf 'review-auth executed'\n").unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&script_path, perms).unwrap();
-    }
+    let script_path = write_executable_script(
+        workspace.path(),
+        "mock-claude.sh",
+        "#!/bin/sh\nprintf 'review-auth executed'\n",
+    );
 
     let discovery_port = 42000 + (rand::random::<u16>() % 1000);
     let mut takuro_config = test_config("takuro", discovery_port);
@@ -307,13 +301,7 @@ description: Review auth
 
     takuro.handle_confirmation_input_for_test('y').unwrap();
 
-    let transcript = takuro
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let transcript = rendered_messages(&takuro);
     assert!(transcript.contains("review-auth executed"));
 }
 
@@ -334,15 +322,11 @@ description: Review auth
     )
     .unwrap();
 
-    let script_path = workspace.path().join("mock-claude.sh");
-    std::fs::write(&script_path, "#!/bin/sh\nprintf 'review-auth executed'\n").unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&script_path, perms).unwrap();
-    }
+    let script_path = write_executable_script(
+        workspace.path(),
+        "mock-claude.sh",
+        "#!/bin/sh\nprintf 'review-auth executed'\n",
+    );
 
     let discovery_port = 43000 + (rand::random::<u16>() % 1000);
     let mut takuro_config = test_config("takuro", discovery_port);
@@ -395,13 +379,7 @@ description: Review auth
     takuro.handle_input_line_for_test(&format!("/trust remove {fingerprint}")).unwrap();
     takuro.handle_input_line_for_test("/run 1").unwrap();
 
-    let transcript = takuro
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let transcript = rendered_messages(&takuro);
     assert!(transcript.contains("removed trust for"));
     assert!(transcript.contains("permission denied: proposal 1 came from untrusted peer tanaka"));
     assert!(takuro.state().pending_confirmation().is_none());

--- a/tests/phase0_commands_e2e.rs
+++ b/tests/phase0_commands_e2e.rs
@@ -1,31 +1,22 @@
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
 
+mod common;
+
+use common::{config_with_ai_script, rendered_messages, write_executable_script};
 use triadchat::application::Application;
 use triadchat::config::Config;
 use triadchat::state::{AiMode, MessageType};
 
-fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
-    let path = dir.path().join(name);
-    fs::write(&path, body).unwrap();
-    let mut permissions = fs::metadata(&path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&path, permissions).unwrap();
-    path
-}
-
 #[test]
 fn summary_commands_and_auto_intervention_work_end_to_end() {
     let dir = TempDir::new().unwrap();
-    let script = write_script(
-        &dir,
+    let script = write_executable_script(
+        dir.path(),
         "mock-claude.sh",
         "#!/bin/sh\ncase \"$2\" in\n  *TASK:summary*) printf 'INTENT: Summary\nTEXT: auth を service に切り出す。takuro が設計し、tanaka が回帰確認する。\nSTRUCTURED: {\"todos\":[{\"text\":\"auth の設計\",\"assignee\":\"takuro\"},{\"text\":\"回帰確認\",\"assignee\":\"tanaka\"}],\"decisions\":[\"auth は service に切り出す\"],\"skill_suggestions\":[]}\n' ;;\n  *TASK:todos*) printf 'INTENT: Todo\nTEXT: TODO を抽出しました\nSTRUCTURED: {\"todos\":[{\"text\":\"auth の設計\",\"assignee\":\"takuro\"}],\"decisions\":[],\"skill_suggestions\":[]}\n' ;;\n  *TASK:intervene*) printf 'INTENT: Summary\nTEXT: 決定事項を整理します\nSTRUCTURED: {\"todos\":[],\"decisions\":[\"auth は service に切り出す\"],\"skill_suggestions\":[]}\n' ;;\n  *) printf 'INTENT: Clarify\nTEXT: fallback\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\n' ;;\nesac\n",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test(&config).unwrap();
 
     app.handle_input_line_for_test("auth serviceに切り出したい").unwrap();
@@ -38,16 +29,7 @@ fn summary_commands_and_auto_intervention_work_end_to_end() {
     app.handle_input_line_for_test("/summary").unwrap();
     app.handle_input_line_for_test("/todos").unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .filter_map(|message| match &message.message_type {
-            MessageType::Text(text) | MessageType::AiText(text) => Some(text.clone()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(rendered.contains("auth を service に切り出す"));
     assert!(rendered.contains("takuro"));
@@ -56,28 +38,18 @@ fn summary_commands_and_auto_intervention_work_end_to_end() {
 #[test]
 fn clerk_mode_intervenes_before_human_streak_limit_when_task_marker_exists() {
     let dir = TempDir::new().unwrap();
-    let script = write_script(
-        &dir,
+    let script = write_executable_script(
+        dir.path(),
         "mock-claude.sh",
         "#!/bin/sh\nprintf 'INTENT: Summary\nTEXT: 自動介入しました\nSTRUCTURED: {\"todos\":[{\"text\":\"auth の設計\",\"assignee\":\"takuro\"}],\"decisions\":[],\"skill_suggestions\":[]}\n'",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test(&config).unwrap();
 
     app.handle_input_line_for_test("takuro が auth の設計を書く").unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .filter_map(|message| match &message.message_type {
-            MessageType::AiText(text) => Some(text.clone()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(rendered.contains("自動介入しました"));
 }
@@ -85,14 +57,13 @@ fn clerk_mode_intervenes_before_human_streak_limit_when_task_marker_exists() {
 #[test]
 fn moderator_mode_does_not_intervene_for_plain_task_language() {
     let dir = TempDir::new().unwrap();
-    let script = write_script(
-        &dir,
+    let script = write_executable_script(
+        dir.path(),
         "mock-claude.sh",
         "#!/bin/sh\nprintf 'INTENT: Summary\nTEXT: moderator intervened\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\n'",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test(&config).unwrap();
 
     app.handle_input_line_for_test("/ai mode moderator").unwrap();
@@ -113,14 +84,13 @@ fn moderator_mode_does_not_intervene_for_plain_task_language() {
 #[test]
 fn slash_commands_are_not_included_in_transcript() {
     let dir = TempDir::new().unwrap();
-    let script = write_script(
-        &dir,
+    let script = write_executable_script(
+        dir.path(),
         "mock-claude.sh",
         "#!/bin/sh\nprintf 'INTENT: Summary\nTEXT: noop\nSTRUCTURED: {\"todos\":[],\"decisions\":[],\"skill_suggestions\":[]}\n'",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test(&config).unwrap();
 
     app.handle_input_line_for_test("auth serviceに切り出したい").unwrap();
@@ -139,13 +109,7 @@ fn help_command_groups_commands_with_descriptions() {
 
     app.handle_input_line_for_test("/help").unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(rendered.contains("【 AI 】"));
     assert!(rendered.contains("【 Summary 】"));
@@ -179,13 +143,7 @@ fn ai_commands_report_human_readable_feedback() {
     app.handle_input_line_for_test("/ai mode moderator").unwrap();
     app.handle_input_line_for_test("/ai freq low").unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(rendered.contains("AI mode set to moderator"));
     assert!(rendered.contains("AI frequency set to low"));
@@ -227,8 +185,7 @@ fn room_list_when_no_rooms_emits_no_rooms() {
 
     app.handle_input_line_for_test("/room list").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("no rooms"));
 }
 
@@ -242,8 +199,7 @@ fn peers_when_no_discovered_peers_emits_no_peers_discovered() {
 
     app.handle_input_line_for_test("/peers").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("no peers discovered"));
 }
 
@@ -257,8 +213,7 @@ fn run_with_unknown_proposal_id_shows_unknown_proposal() {
 
     app.handle_input_line_for_test("/run 1").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("unknown proposal id: 1"));
 }
 
@@ -272,8 +227,7 @@ fn cancel_with_no_active_task_emits_no_active_task() {
 
     app.handle_input_line_for_test("/cancel").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("no active task"));
 }
 
@@ -287,8 +241,7 @@ fn avatar_set_with_unknown_preset_warns_unknown_avatar_preset() {
 
     app.handle_input_line_for_test("/avatar set self nonexistent_avatar").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("Unknown avatar preset 'nonexistent_avatar'"));
 }
 
@@ -300,8 +253,7 @@ fn avatar_set_with_unknown_target_warns_unknown_target() {
 
     app.handle_input_line_for_test("/avatar set nope_user robot_guardian").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("Unknown target 'nope_user'"));
 }
 
@@ -315,7 +267,6 @@ fn avatar_mode_with_unknown_mode_warns_unknown_avatar_mode() {
 
     app.handle_input_line_for_test("/avatar mode bogus").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("Unknown avatar mode 'bogus'"));
 }

--- a/tests/phase1_commands_e2e.rs
+++ b/tests/phase1_commands_e2e.rs
@@ -1,20 +1,12 @@
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 
 use tempfile::TempDir;
 
-use triadchat::application::{Application, Signal};
-use triadchat::config::{AiConfig, Config};
-use triadchat::message::{AiIntent, AiPayload, StructuredOutput};
+mod common;
 
-fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
-    let path = dir.path().join(name);
-    fs::write(&path, body).unwrap();
-    let mut permissions = fs::metadata(&path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&path, permissions).unwrap();
-    path
-}
+use common::{config_with_ai_script, rendered_messages, write_executable_script};
+use triadchat::application::{Application, Signal};
+use triadchat::message::{AiIntent, AiPayload, StructuredOutput};
 
 fn create_skill_workspace() -> TempDir {
     let dir = TempDir::new().unwrap();
@@ -39,14 +31,13 @@ args_hint: <ticket-id>
 #[test]
 fn phase1_skill_commands_execute_without_polluting_transcript() {
     let workspace = create_skill_workspace();
-    let script = write_script(
-        &workspace,
+    let script = write_executable_script(
+        workspace.path(),
         "mock-claude.sh",
         "#!/bin/sh\nprintf 'review-auth finished successfully'\n",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
     let node = app.node_handler();
 
@@ -70,13 +61,7 @@ fn phase1_skill_commands_execute_without_polluting_transcript() {
     app.handle_input_line_for_test("/run 1").unwrap();
     app.handle_confirmation_input_for_test('y').unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("name"));
     assert!(rendered.contains("risk"));
     assert!(rendered.contains("mode"));
@@ -98,14 +83,13 @@ fn phase1_skill_commands_execute_without_polluting_transcript() {
 #[test]
 fn confirmation_flow_cancels_with_n() {
     let workspace = create_skill_workspace();
-    let script = write_script(
-        &workspace,
+    let script = write_executable_script(
+        workspace.path(),
         "mock-claude.sh",
         "#!/bin/sh\nprintf 'review-auth finished successfully'\n",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
     let node = app.node_handler();
 
@@ -129,8 +113,7 @@ fn confirmation_flow_cancels_with_n() {
 
     assert!(app.state().pending_confirmation().is_none(), "pending confirmation should be cleared");
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("skill execution cancelled"));
     assert!(
         !rendered.contains("review-auth finished successfully"),
@@ -143,14 +126,13 @@ fn confirmation_flow_cancels_with_n() {
 #[test]
 fn cancel_with_pending_confirmation_but_no_running_task_cancels_confirmation() {
     let workspace = create_skill_workspace();
-    let script = write_script(
-        &workspace,
+    let script = write_executable_script(
+        workspace.path(),
         "mock-claude.sh",
         "#!/bin/sh\nprintf 'review-auth finished successfully'\n",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
     let node = app.node_handler();
 
@@ -180,8 +162,7 @@ fn cancel_with_pending_confirmation_but_no_running_task_cancels_confirmation() {
         "pending confirmation should be cleared after /cancel"
     );
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("skill execution cancelled"));
 }
 
@@ -190,13 +171,9 @@ fn cancel_with_pending_confirmation_but_no_running_task_cancels_confirmation() {
 #[test]
 fn run_proposal_from_untrusted_remote_peer_is_permission_denied() {
     let workspace = create_skill_workspace();
-    let script = write_script(&workspace, "mock-claude.sh", "#!/bin/sh\nprintf 'noop'\n");
-
-    let config = Config {
-        user_name: "takuro".into(),
-        ai: AiConfig { command: Some(script.display().to_string()), ..Default::default() },
-        ..Default::default()
-    };
+    let script =
+        write_executable_script(workspace.path(), "mock-claude.sh", "#!/bin/sh\nprintf 'noop'\n");
+    let config = config_with_ai_script(&script, "takuro");
 
     let mut takuro = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
 
@@ -219,8 +196,7 @@ fn run_proposal_from_untrusted_remote_peer_is_permission_denied() {
         "permission denied should not leave pending confirmation"
     );
 
-    let rendered =
-        takuro.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&takuro);
     assert!(rendered.contains("permission denied"));
     assert!(rendered.contains("untrusted peer tanaka"));
     assert!(

--- a/tests/skill_confirmation_messages.rs
+++ b/tests/skill_confirmation_messages.rs
@@ -1,8 +1,10 @@
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 
 use tempfile::TempDir;
 
+mod common;
+
+use common::{rendered_messages, write_executable_script};
 use triadchat::application::Application;
 use triadchat::config::Config;
 
@@ -25,15 +27,6 @@ description: Deploy to production
     dir
 }
 
-fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
-    let path = dir.path().join(name);
-    fs::write(&path, body).unwrap();
-    let mut permissions = fs::metadata(&path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&path, permissions).unwrap();
-    path
-}
-
 /// Regression test for issue #4: confirmation prompt must be in English.
 #[test]
 fn skill_confirmation_prompt_is_in_english() {
@@ -44,8 +37,7 @@ fn skill_confirmation_prompt_is_in_english() {
 
     app.handle_input_line_for_test("/skill deploy-prod").unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(
         rendered.contains("[deploy-prod] Execute this skill? [y/n]"),
@@ -61,8 +53,11 @@ fn skill_confirmation_prompt_is_in_english() {
 #[test]
 fn skill_running_message_is_in_english() {
     let workspace = create_confirm_skill_workspace();
-    let script =
-        write_script(&workspace, "mock-claude.sh", "#!/bin/sh\nprintf 'deploy-prod finished'\n");
+    let script = write_executable_script(
+        workspace.path(),
+        "mock-claude.sh",
+        "#!/bin/sh\nprintf 'deploy-prod finished'\n",
+    );
 
     let mut config = Config::default();
     config.ai.command = Some(script.display().to_string());
@@ -71,8 +66,7 @@ fn skill_running_message_is_in_english() {
     app.handle_input_line_for_test("/skill deploy-prod").unwrap();
     app.handle_confirmation_input_for_test('y').unwrap();
 
-    let rendered =
-        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(
         rendered.contains("[ops-ai: running /deploy-prod...]"),

--- a/tests/skill_executor.rs
+++ b/tests/skill_executor.rs
@@ -1,23 +1,16 @@
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
 
 use tempfile::TempDir;
 
+mod common;
+
+use common::{config_with_ai_script, rendered_messages, write_executable_script};
 use triadchat::application::{Application, Signal};
 use triadchat::config::Config;
 use triadchat::message::{AiIntent, AiPayload, StructuredOutput};
 use triadchat::skill::registry::{InvokeMode, RiskLevel};
 use triadchat::state::AiState;
-
-fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
-    let path = dir.path().join(name);
-    fs::write(&path, body).unwrap();
-    let mut permissions = fs::metadata(&path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&path, permissions).unwrap();
-    path
-}
 
 fn create_skill_workspace() -> TempDir {
     let dir = TempDir::new().unwrap();
@@ -59,14 +52,13 @@ description: Summarise text
 #[test]
 fn skill_command_requires_confirmation_then_posts_result() {
     let workspace = create_skill_workspace();
-    let script = write_script(
-        &workspace,
+    let script = write_executable_script(
+        workspace.path(),
         "mock-claude.sh",
         "#!/bin/sh\nprintf 'review-auth finished successfully'\n",
     );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
 
     app.handle_input_line_for_test("/skill review-auth").unwrap();
@@ -78,13 +70,7 @@ fn skill_command_requires_confirmation_then_posts_result() {
 
     app.handle_confirmation_input_for_test('y').unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(rendered.contains("review-auth finished successfully"));
     assert_eq!(app.state().ai_state, AiState::Idle);
@@ -93,11 +79,13 @@ fn skill_command_requires_confirmation_then_posts_result() {
 #[test]
 fn cancel_stops_running_skill_task() {
     let workspace = create_skill_workspace();
-    let script =
-        write_script(&workspace, "slow-claude.sh", "#!/bin/sh\nsleep 2\nprintf 'late result'\n");
+    let script = write_executable_script(
+        workspace.path(),
+        "slow-claude.sh",
+        "#!/bin/sh\nsleep 2\nprintf 'late result'\n",
+    );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_in_workspace(&config, workspace.path()).unwrap();
 
     app.handle_input_line_for_test("/skill review-auth").unwrap();
@@ -111,11 +99,13 @@ fn cancel_stops_running_skill_task() {
 #[test]
 fn run_uses_pending_skill_proposals_from_ai_response() {
     let workspace = create_skill_workspace();
-    let script =
-        write_script(&workspace, "mock-claude.sh", "#!/bin/sh\nprintf 'proposal executed'\n");
+    let script = write_executable_script(
+        workspace.path(),
+        "mock-claude.sh",
+        "#!/bin/sh\nprintf 'proposal executed'\n",
+    );
 
-    let mut config = Config::default();
-    config.ai.command = Some(script.display().to_string());
+    let config = config_with_ai_script(&script, "takuro");
     let mut app = Application::new_for_test_in_workspace(&config, workspace.path()).unwrap();
     let node = app.node_handler();
 
@@ -140,13 +130,7 @@ fn run_uses_pending_skill_proposals_from_ai_response() {
 
     app.handle_confirmation_input_for_test('y').unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
     assert!(rendered.contains("proposal executed"));
 }
 
@@ -159,13 +143,7 @@ fn suggest_only_skill_explains_how_to_run_it() {
 
     app.handle_input_line_for_test("/skill summarise").unwrap();
 
-    let rendered = app
-        .state()
-        .messages()
-        .iter()
-        .map(|message| message.rendered_text())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let rendered = rendered_messages(&app);
 
     assert!(rendered.contains("Skill 'summarise' is propose-only"));
     assert!(rendered.contains("/run <id>"));


### PR DESCRIPTION
## Summary
- Add shared integration test helpers for executable mock scripts, rendered message collection, and AI script configs
- Replace duplicated helper code in command, skill, and network integration tests
- Clean up single-item import braces in small Rust modules

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

Note: the avatar loader clippy fix from the original local plan was already present in latest origin/main after rebasing.