### PR TITLE
Fix multiline AI text parsing

### DIFF
--- a/src/ai/parser.rs
+++ b/src/ai/parser.rs
@@ -4,15 +4,33 @@ pub fn parse_ai_payload(raw: &str) -> AiPayload {
     let mut intent = None;
     let mut text = None;
     let mut structured = None;
+    let mut text_buffer: Option<String> = None;
 
     for line in raw.lines() {
         if let Some(value) = line.strip_prefix("INTENT:") {
+            if let Some(value) = text_buffer.take() {
+                text = Some(value.trim().to_string());
+            }
             intent = Some(parse_intent(value.trim()));
         } else if let Some(value) = line.strip_prefix("TEXT:") {
-            text = Some(value.trim().to_string());
+            if let Some(value) = text_buffer.take() {
+                text = Some(value.trim().to_string());
+            }
+            text_buffer = Some(value.trim().to_string());
         } else if let Some(value) = line.strip_prefix("STRUCTURED:") {
+            if let Some(value) = text_buffer.take() {
+                text = Some(value.trim().to_string());
+            }
             structured = serde_json::from_str::<StructuredOutput>(value.trim()).ok();
+        } else if let Some(value) = text_buffer.as_mut() {
+            if !value.is_empty() {
+                value.push('\n');
+            }
+            value.push_str(line);
         }
+    }
+    if let Some(value) = text_buffer {
+        text = Some(value.trim().to_string());
     }
 
     match (intent, text) {

--- a/tests/prompt_quality.rs
+++ b/tests/prompt_quality.rs
@@ -41,6 +41,16 @@ fn parser_extracts_structured_output() {
 }
 
 #[test]
+fn parser_collects_multiline_text_until_next_prefix() {
+    let raw = "INTENT: Summary\nTEXT: First line\nSecond line\nThird line\nSTRUCTURED: {\"todos\":[],\"decisions\":[\"ship it\"],\"skill_suggestions\":[]}\n";
+    let payload = parse_ai_payload(raw);
+
+    assert_eq!(payload.intent, AiIntent::Summary);
+    assert_eq!(payload.text, "First line\nSecond line\nThird line");
+    assert_eq!(payload.structured.as_ref().unwrap().decisions, vec!["ship it".to_string()]);
+}
+
+#[test]
 fn parser_falls_back_without_panicking() {
     let payload = parse_ai_payload("unexpected raw response");
     assert_eq!(payload.intent, AiIntent::Clarify);

--- a/tests/prompt_quality.rs
+++ b/tests/prompt_quality.rs
@@ -51,6 +51,15 @@ fn parser_collects_multiline_text_until_next_prefix() {
 }
 
 #[test]
+fn parser_collects_multiline_text_until_end_of_string() {
+    let raw = "INTENT: Summary\nTEXT: First line\nSecond line\nThird line";
+    let payload = parse_ai_payload(raw);
+
+    assert_eq!(payload.intent, AiIntent::Summary);
+    assert_eq!(payload.text, "First line\nSecond line\nThird line");
+}
+
+#[test]
 fn parser_falls_back_without_panicking() {
     let payload = parse_ai_payload("unexpected raw response");
     assert_eq!(payload.intent, AiIntent::Clarify);


### PR DESCRIPTION
## Summary
- collect continuation lines after TEXT: until the next AI payload prefix
- add prompt parser regression coverage for multiline TEXT fields

Closes #65

## Verification
- cargo check
- cargo test --test prompt_quality parser_collects_multiline_text_until_next_prefix (failed before implementation, passed after)
- cargo test --test prompt_quality
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --test phase0_commands_e2e --test phase1_commands_e2e
- cargo test
- git diff --check

## Notes
- cargo audit currently fails on pre-existing dependency advisories unrelated to this parser change: RUSTSEC-2024-0019 (mio), RUSTSEC-2025-0141 (bincode unmaintained), RUSTSEC-2024-0384 (instant unmaintained), RUSTSEC-2023-0049 (tui unmaintained), and RUSTSEC-2026-0097 (rand warning).