### PR TITLE
Fix unknown language fallback

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -247,7 +247,8 @@ impl LanguageConfig {
             "en" => Self { ai_output: "en".into(), ui: "en".into() },
             "zh" => Self { ai_output: "zh".into(), ui: "en".into() },
             "ko" => Self { ai_output: "ko".into(), ui: "en".into() },
-            _ => Self { ai_output: "ja".into(), ui: "ja".into() },
+            "ja" => Self { ai_output: "ja".into(), ui: "ja".into() },
+            _ => Self { ai_output: "en".into(), ui: "en".into() },
         }
     }
 

--- a/tests/phase0_basics.rs
+++ b/tests/phase0_basics.rs
@@ -38,6 +38,6 @@ fn language_defaults_follow_lang_environment() {
     assert_eq!(zh.ui, "en");
 
     let fallback = LanguageConfig::from_lang_env_value(Some("unknown"));
-    assert_eq!(fallback.ai_output, "ja");
-    assert_eq!(fallback.ui, "ja");
+    assert_eq!(fallback.ai_output, "en");
+    assert_eq!(fallback.ui, "en");
 }


### PR DESCRIPTION
## Summary
- Default unsupported or unknown LANG values to English instead of Japanese
- Preserve explicit ja/en/zh/ko mappings
- Update the regression test for the new fallback rule

Closes #69

## Verification
- cargo test --test phase0_basics language_defaults_follow_lang_environment
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --test phase0_commands_e2e --test phase1_commands_e2e
- cargo test
- git diff --check