### PR TITLE
Reuse transcript writer for active room

### DIFF
--- a/src/room/transcript.rs
+++ b/src/room/transcript.rs
@@ -99,3 +99,9 @@ impl TranscriptWriter {
         writer.append(entry)
     }
 }
+
+impl Drop for TranscriptWriter {
+    fn drop(&mut self) {
+        let _ = self.file.flush();
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -164,6 +164,7 @@ pub struct State {
     pending_confirmation: Option<PendingSkillExecution>,
     pending_skill_proposals: Vec<SkillProposal>,
     transcript_base_dir: Option<PathBuf>,
+    transcript_writer: Option<(String, TranscriptWriter)>,
     trusted_peer_fingerprints: HashSet<String>,
     pub stop_stream: bool,
     pub windows: HashMap<Endpoint, Window>,
@@ -210,6 +211,7 @@ impl Default for State {
             pending_confirmation: None,
             pending_skill_proposals: Vec::new(),
             transcript_base_dir: None,
+            transcript_writer: None,
             trusted_peer_fingerprints: HashSet::new(),
             stop_stream: false,
             windows: HashMap::new(),
@@ -466,6 +468,7 @@ impl State {
 
     pub fn set_transcript_base_dir(&mut self, transcript_base_dir: Option<PathBuf>) {
         self.transcript_base_dir = transcript_base_dir;
+        self.transcript_writer = None;
     }
 
     pub fn set_trusted_peer_fingerprints(
@@ -964,8 +967,31 @@ impl State {
     }
 
     fn write_transcript_entry(&mut self, entry: TranscriptEntry) {
-        if let Some(base_dir) = self.transcript_base_dir.as_ref() {
-            let _ = TranscriptWriter::append_to_base(base_dir, &entry);
+        let Some(base_dir) = self.transcript_base_dir.clone() else {
+            return;
+        };
+
+        let room_id = entry.room_id.clone();
+        let needs_new_writer = self
+            .transcript_writer
+            .as_ref()
+            .map(|(active_room_id, _)| active_room_id != &room_id)
+            .unwrap_or(true);
+
+        if needs_new_writer {
+            match TranscriptWriter::open_with_base(base_dir, &room_id) {
+                Ok(writer) => self.transcript_writer = Some((room_id, writer)),
+                Err(_) => {
+                    self.transcript_writer = None;
+                    return;
+                }
+            }
+        }
+
+        if let Some((_, writer)) = self.transcript_writer.as_mut() {
+            if writer.append(&entry).is_err() {
+                self.transcript_writer = None;
+            }
         }
     }
 

--- a/tests/transcript.rs
+++ b/tests/transcript.rs
@@ -1,6 +1,7 @@
 use tempfile::TempDir;
 
 use triadchat::room::transcript::{TranscriptEntry, TranscriptWriter};
+use triadchat::state::{ChatMessage, MessageType, State};
 
 #[test]
 fn transcript_writer_appends_jsonl_entries() {
@@ -47,4 +48,36 @@ fn transcript_writer_routes_entries_to_room_specific_files() {
 
     assert!(base.path().join("triadchat/transcripts/room-a.jsonl").exists());
     assert!(base.path().join("triadchat/transcripts/room-b.jsonl").exists());
+}
+
+#[test]
+fn state_reuses_open_transcript_writer_for_active_room() {
+    let base = TempDir::new().unwrap();
+    let mut state = State::default();
+    state.set_local_user_name("takuro");
+    state.set_transcript_base_dir(Some(base.path().to_path_buf()));
+
+    state.add_message(ChatMessage::new("takuro".into(), MessageType::Text("first".into())));
+
+    let path = base.path().join("triadchat/transcripts/solo-takuro.jsonl");
+    let renamed_path = base.path().join("triadchat/transcripts/solo-takuro-renamed.jsonl");
+    std::fs::rename(&path, &renamed_path).unwrap();
+
+    state.add_message(ChatMessage::new("takuro".into(), MessageType::Text("second".into())));
+    drop(state);
+
+    assert!(
+        !path.exists(),
+        "writer should keep using the open handle instead of reopening by path"
+    );
+
+    let raw = std::fs::read_to_string(renamed_path).unwrap();
+    let entries = raw
+        .lines()
+        .map(|line| serde_json::from_str::<TranscriptEntry>(line).unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].text, "first");
+    assert_eq!(entries[1].text, "second");
 }


### PR DESCRIPTION
## Summary
- Keep an open TranscriptWriter in State and reopen only when the target room changes
- Reset the cached writer when transcript base directory changes or writes fail
- Add a regression test proving repeated active-room writes do not reopen by path

Closes #71

## Verification
- cargo test --test transcript state_reuses_open_transcript_writer_for_active_room
- cargo test --test transcript
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --test phase0_commands_e2e --test phase1_commands_e2e
- cargo test
- git diff --check