### PR TITLE
Remove video streaming remnants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,12 +117,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -362,15 +344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible_collections"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,15 +393,6 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -930,26 +894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "resize"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e7bdfff05e26408cf8f82fe896ce3d7624f0c0b06c84b2f1009c50452ead41"
-dependencies = [
- "fallible_collections",
- "rgb",
-]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
-dependencies = [
- "bytemuck",
- "serde",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,8 +1296,6 @@ dependencies = [
  "libloading",
  "message-io",
  "rand",
- "resize",
- "rgb",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ shellwords = "1.1.0"
 shellexpand = "2.1.0"
 toml = "0.5.8"
 dirs-next = "2.0.0"
-rgb = {version="0.8.25", features=["serde"]}
-resize = "0.7.0"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -37,7 +37,7 @@ use crate::room::{MemberKind, Room};
 use crate::renderer::Renderer;
 use crate::state::{
     AiFrequency, AiMode, AiState, ChatMessage, CursorMovement, MessageType, ScrollMovement, State,
-    Window, PeerReadiness,
+    PeerReadiness,
 };
 use crate::skill::executor::{PendingSkillExecution, SkillExecutor};
 use crate::skill::registry::{InvokeMode, RiskLevel};
@@ -270,7 +270,6 @@ impl<'a> Application<'a> {
                 },
                 NetEvent::Disconnected(endpoint) => {
                     self.state.disconnected_user(endpoint);
-                    self.state.windows.remove(&endpoint);
                     self.ring_the_bell();
                 }
             },
@@ -369,18 +368,6 @@ impl<'a> Application<'a> {
                     }
                 }
             }
-            NetMessage::Stream(data) => match data {
-                Some((data, width, height)) if data.len() == width * height / 2 => {
-                    self.state
-                        .windows
-                        .entry(endpoint)
-                        .or_insert_with(|| Window::new(width, height));
-                    self.state.update_window(&endpoint, data, width, height);
-                }
-                _ => {
-                    self.state.windows.remove(&endpoint);
-                }
-            },
             NetMessage::AiMessage(payload) => self.process_remote_ai_response(endpoint, payload),
             NetMessage::PeerInfo(peer) => {
                 self.state.connected_user(endpoint, &peer.user_name);

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,3 @@
-use rgb::RGB8;
 use serde::{Deserialize, Serialize};
 
 use crate::state::AiMode;
@@ -89,7 +88,6 @@ pub enum NetMessage {
     HelloUser(String),
     UserMessage(String),
     UserData(String, Chunk),
-    Stream(Option<(Vec<RGB8>, usize, usize)>),
     AiMessage(AiPayload),
     PeerInfo(PeerInfo),
     RoomCreate(RoomId, Vec<MemberId>),

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,6 @@ use std::time::Instant;
 
 use chrono::{DateTime, Local};
 use message_io::network::Endpoint;
-use rgb::RGB8;
 use sha2::{Digest, Sha256};
 use tokio::task::AbortHandle;
 
@@ -134,18 +133,6 @@ impl ChatMessage {
     }
 }
 
-pub struct Window {
-    pub data: Vec<RGB8>,
-    pub width: usize,
-    pub height: usize,
-}
-
-impl Window {
-    pub fn new(width: usize, height: usize) -> Self {
-        Self { data: vec![], width, height }
-    }
-}
-
 pub struct State {
     messages: Vec<ChatMessage>,
     scroll_messages_view: usize,
@@ -166,8 +153,6 @@ pub struct State {
     transcript_base_dir: Option<PathBuf>,
     transcript_writer: Option<(String, TranscriptWriter)>,
     trusted_peer_fingerprints: HashSet<String>,
-    pub stop_stream: bool,
-    pub windows: HashMap<Endpoint, Window>,
     pub ai_state: AiState,
     pub ai_provider: AiProvider,
     pub ai_mode: AiMode,
@@ -213,8 +198,6 @@ impl Default for State {
             transcript_base_dir: None,
             transcript_writer: None,
             trusted_peer_fingerprints: HashSet::new(),
-            stop_stream: false,
-            windows: HashMap::new(),
             ai_state: AiState::Idle,
             ai_provider: AiProvider::Claude,
             ai_mode: AiMode::Clerk,
@@ -911,20 +894,6 @@ impl State {
                 }
                 ProgressState::Completed => ProgressState::Completed,
             };
-        }
-    }
-
-    pub fn update_window(
-        &mut self,
-        endpoint: &Endpoint,
-        data: Vec<RGB8>,
-        width: usize,
-        height: usize,
-    ) {
-        if let Some(window) = self.windows.get_mut(endpoint) {
-            window.data = data;
-            window.width = width;
-            window.height = height;
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,9 +4,6 @@ pub mod peers_panel;
 pub mod room_list_panel;
 pub mod status_panel;
 
-use resize::px::RGB;
-use resize::Pixel::RGB8;
-use resize::Type::Lanczos3;
 use tui::backend::Backend;
 use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Modifier, Style};
@@ -18,7 +15,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::avatar::loader::AvatarManager;
 use crate::commands::CommandManager;
 use crate::config::{LanguageConfig, Theme};
-use crate::state::{MessageType, ProgressState, State, SystemMessageType, Window};
+use crate::state::{MessageType, ProgressState, State, SystemMessageType};
 use crate::ui::layout::should_show_side_panels;
 use crate::ui::messages::messages;
 use crate::ui::peers_panel::draw_peers_panel;
@@ -74,16 +71,7 @@ pub fn draw(
         draw_peers_panel(frame, state, left_chunks[0], avatar_manager);
         draw_room_list_panel(frame, state, left_chunks[1]);
 
-        if !state.windows.is_empty() {
-            let chat_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Min(0), Constraint::Length(30)].as_ref())
-                .split(right_chunks[0]);
-            draw_messages_panel(frame, state, chat_chunks[0], theme, language);
-            draw_video_panel(frame, state, chat_chunks[1]);
-        } else {
-            draw_messages_panel(frame, state, right_chunks[0], theme, language);
-        }
+        draw_messages_panel(frame, state, right_chunks[0], theme, language);
 
         draw_status_panel(frame, state, right_chunks[1], avatar_manager);
     } else {
@@ -93,16 +81,7 @@ pub fn draw(
             .constraints(layout::right_column_constraints())
             .split(upper_chunk);
 
-        if !state.windows.is_empty() {
-            let chat_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Min(0), Constraint::Length(30)].as_ref())
-                .split(right_chunks[0]);
-            draw_messages_panel(frame, state, chat_chunks[0], theme, language);
-            draw_video_panel(frame, state, chat_chunks[1]);
-        } else {
-            draw_messages_panel(frame, state, right_chunks[0], theme, language);
-        }
+        draw_messages_panel(frame, state, right_chunks[0], theme, language);
 
         draw_status_panel(frame, state, right_chunks[1], avatar_manager);
     }
@@ -363,12 +342,6 @@ fn draw_input_panel(frame: &mut Frame<impl Backend>, state: &State, chunk: Rect,
     frame.set_cursor(chunk.x + 1 + input_cursor.0, chunk.y + 1 + input_cursor.1)
 }
 
-fn draw_video_panel(frame: &mut Frame<impl Backend>, state: &State, chunk: Rect) {
-    let windows = state.windows.values().collect();
-    let fb = FrameBuffer::new(windows).block(Block::default().borders(Borders::ALL));
-    frame.render_widget(fb, chunk);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -455,63 +428,5 @@ mod tests {
         assert_eq!(spans[0].content, "Just an ");
         assert_eq!(spans[1].content, "@");
         assert_eq!(spans[2].content, " symbol");
-    }
-}
-
-#[derive(Default)]
-struct FrameBuffer<'a> {
-    windows: Vec<&'a Window>,
-    block: Option<Block<'a>>,
-}
-
-impl<'a> FrameBuffer<'a> {
-    fn new(windows: Vec<&'a Window>) -> Self {
-        Self { windows, ..Default::default() }
-    }
-
-    fn block(mut self, block: Block<'a>) -> FrameBuffer<'a> {
-        self.block = Some(block);
-        self
-    }
-}
-
-impl tui::widgets::Widget for FrameBuffer<'_> {
-    fn render(mut self, area: Rect, buf: &mut tui::buffer::Buffer) {
-        let area = match self.block.take() {
-            Some(block) => {
-                let inner = block.inner(area);
-                block.render(area, buf);
-                inner
-            }
-            None => area,
-        };
-
-        let windows_num = self.windows.len();
-        let window_height = area.height / windows_num as u16;
-        let y_start = area.y;
-        for (idx, window) in self.windows.iter().enumerate() {
-            let area =
-                Rect::new(area.x, y_start + window_height * idx as u16, area.width, window_height);
-
-            let mut resizer = resize::new(
-                window.width / 2,
-                window.height,
-                area.width as usize,
-                area.height as usize,
-                RGB8,
-                Lanczos3,
-            )
-            .unwrap();
-            let mut dst = vec![RGB::new(0, 0, 0); (area.width * area.height) as usize];
-            resizer.resize(&window.data, &mut dst).unwrap();
-
-            let mut dst = dst.iter();
-            for j in area.y..area.y + area.height {
-                for i in area.x..area.x + area.width {
-                    let rgb = dst.next().unwrap();
-                    buf.get_mut(i, j).set_bg(Color::Rgb(rgb.r, rgb.g, rgb.b));
-                }
-            }
-        }
     }
 }

--- a/tests/net_message_phase1.rs
+++ b/tests/net_message_phase1.rs
@@ -7,7 +7,6 @@ enum LegacyNetMessage {
     HelloUser(String),
     UserMessage(String),
     UserData(String, Chunk),
-    Stream(Option<(Vec<rgb::RGB8>, usize, usize)>),
     AiMessage(AiPayload),
     PeerInfo(PeerInfo),
     RoomCreate(String, Vec<String>),

--- a/tests/sidecar_mock.rs
+++ b/tests/sidecar_mock.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
@@ -10,7 +11,10 @@ use triadchat::config::{AiConfig, AiProvider};
 
 fn write_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
     let path = dir.path().join(name);
-    fs::write(&path, body).unwrap();
+    let mut file = fs::File::create(&path).unwrap();
+    file.write_all(body.as_bytes()).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
     let mut permissions = fs::metadata(&path).unwrap().permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&path, permissions).unwrap();

--- a/tests/video_removed.rs
+++ b/tests/video_removed.rs
@@ -1,0 +1,19 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn video_streaming_code_and_dependency_are_removed() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let cargo_toml = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+    assert!(!cargo_toml.contains("resize ="), "resize dependency should be removed");
+
+    let message_rs = fs::read_to_string(root.join("src/message.rs")).unwrap();
+    assert!(
+        !message_rs.contains("Stream("),
+        "NetMessage::Stream should be removed with video streaming"
+    );
+
+    let ui_rs = fs::read_to_string(root.join("src/ui.rs")).unwrap();
+    assert!(!ui_rs.contains("draw_video_panel"), "video rendering panel should be removed");
+}


### PR DESCRIPTION
## Summary
- Remove the remaining video stream NetMessage variant and stream-handling state/UI paths
- Drop obsolete resize/rgb direct dependencies
- Add a regression test that asserts video streaming code and dependency stay removed

Closes #68

## Verification
- cargo test --test video_removed
- cargo test --test net_message_phase1
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --test phase0_commands_e2e --test phase1_commands_e2e
- cargo test
- git diff --check

## Note
This intentionally removes the legacy Stream protocol variant to match SPEC.md's video stream exclusion.