### PR TITLE
Align wide UI with three-pane spec

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -19,7 +19,6 @@ use crate::state::{MessageType, ProgressState, State, SystemMessageType};
 use crate::ui::layout::should_show_side_panels;
 use crate::ui::messages::messages;
 use crate::ui::peers_panel::draw_peers_panel;
-use crate::ui::room_list_panel::draw_room_list_panel;
 use crate::ui::status_panel::draw_status_panel;
 use crate::util::split_each;
 
@@ -42,38 +41,21 @@ pub fn draw(
     if should_show_side_panels(chunk.width) {
         // ── Wide layout ────────────────────────────────────────────────────
         //
-        //  ┌──────────┬──────────────────────┐
-        //  │  Peers   │        Chat          │
-        //  │──────────┤──────────────────────┤
-        //  │  Rooms   │       ops-ai         │
-        //  ├──────────┴──────────────────────┤
-        //  │              Input              │
-        //  └─────────────────────────────────┘
+        //  ┌──────────┬──────────────────────┬──────────────┐
+        //  │  Peers   │        Chat          │    ops-ai    │
+        //  ├──────────┴──────────────────────┴──────────────┤
+        //  │                    Input                       │
+        //  └────────────────────────────────────────────────┘
         //
-        // Horizontal: left column(18) | right column(min)
+        // Horizontal: peers(18) | chat(min) | status(22)
         let h_chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints(layout::left_right_constraints())
+            .constraints(layout::three_pane_constraints())
             .split(upper_chunk);
 
-        // Left column: peers(min) above, rooms(scaled) below
-        let left_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(layout::left_column_constraints(upper_chunk.height))
-            .split(h_chunks[0]);
-
-        // Right column: chat(min) above, ops-ai(11) below
-        let right_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(layout::right_column_constraints())
-            .split(h_chunks[1]);
-
-        draw_peers_panel(frame, state, left_chunks[0], avatar_manager);
-        draw_room_list_panel(frame, state, left_chunks[1]);
-
-        draw_messages_panel(frame, state, right_chunks[0], theme, language);
-
-        draw_status_panel(frame, state, right_chunks[1], avatar_manager);
+        draw_peers_panel(frame, state, h_chunks[0], avatar_manager);
+        draw_messages_panel(frame, state, h_chunks[1], theme, language);
+        draw_status_panel(frame, state, h_chunks[2], avatar_manager);
     } else {
         // ── Narrow layout: chat above, ops-ai below ─────────────────────────
         let right_chunks = Layout::default()

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,7 +1,11 @@
 use tui::layout::Constraint;
 
-/// Horizontal split: [peers(18), right(min)].
-/// Peers spans the full height of the upper area (above input).
+/// Phase 2 wide split: [peers(18), chat(min), status(22)].
+pub fn three_pane_constraints() -> Vec<Constraint> {
+    vec![Constraint::Length(18), Constraint::Min(0), Constraint::Length(22)]
+}
+
+/// Legacy horizontal split: [peers(18), right(min)].
 pub fn left_right_constraints() -> Vec<Constraint> {
     vec![Constraint::Length(18), Constraint::Min(0)]
 }

--- a/tests/ui_layout.rs
+++ b/tests/ui_layout.rs
@@ -1,5 +1,6 @@
 use triadchat::avatar::AvatarSize;
-use triadchat::ui::layout::should_show_side_panels;
+use triadchat::ui::layout::{should_show_side_panels, three_pane_constraints};
+use tui::layout::Constraint;
 
 #[test]
 fn side_panel_visibility_and_avatar_size_change_at_same_boundary() {
@@ -12,4 +13,20 @@ fn side_panel_visibility_and_avatar_size_change_at_same_boundary() {
         assert_eq!(should_show_side_panels(cols), should_show_panels);
         assert_eq!(AvatarSize::for_width(cols), avatar_size);
     }
+}
+
+#[test]
+fn wide_layout_uses_spec_three_pane_constraints() {
+    assert_eq!(
+        three_pane_constraints(),
+        vec![Constraint::Length(18), Constraint::Min(0), Constraint::Length(22)]
+    );
+}
+
+#[test]
+fn wide_draw_path_uses_three_pane_constraints() {
+    let ui_source =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ui.rs")).unwrap();
+
+    assert!(ui_source.contains("layout::three_pane_constraints()"));
 }


### PR DESCRIPTION
## Summary
- Change the wide TUI layout to the SPEC.md Phase 2 three-column split: peers(18), chat(min), status(22)
- Keep the narrow fallback as chat above ops-ai status
- Add regression coverage for the three-pane constraints and wide draw path

Closes #67

## Verification
- cargo test --test ui_layout wide_layout_uses_spec_three_pane_constraints
- cargo test --test ui_layout --test room_list_panel
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --test phase0_commands_e2e --test phase1_commands_e2e
- cargo test
- git diff --check