### PR TITLE
security: bound inbound NetMessage frame sizes and payloads (#81)

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -261,13 +261,26 @@ impl<'a> Application<'a> {
         match event {
             NodeEvent::Network(net_event) => match net_event {
                 NetEvent::Connected(_, _) | NetEvent::Accepted(_, _) => {}
-                NetEvent::Message(endpoint, message) => match encoder::decode(&message) {
-                    Some(net_message) => self.process_network_message(endpoint, net_message),
-                    None => self.state.add_system_warn_message(format!(
-                        "ignored incompatible message from {}",
-                        endpoint.addr()
-                    )),
-                },
+                NetEvent::Message(endpoint, message) => {
+                    if message.len() > encoder::MAX_FRAME_SIZE {
+                        self.state.add_system_warn_message(format!(
+                            "ignored oversized message from {} ({} bytes, max {})",
+                            endpoint.addr(),
+                            message.len(),
+                            encoder::MAX_FRAME_SIZE
+                        ));
+                    } else {
+                        match encoder::decode(&message) {
+                            Some(net_message) => {
+                                self.process_network_message(endpoint, net_message)
+                            }
+                            None => self.state.add_system_warn_message(format!(
+                                "ignored incompatible or invalid message from {}",
+                                endpoint.addr()
+                            )),
+                        }
+                    }
+                }
                 NetEvent::Disconnected(endpoint) => {
                     self.state.disconnected_user(endpoint);
                     self.ring_the_bell();

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,4 +1,8 @@
-use serde::{Serialize, Deserialize};
+use serde::Serialize;
+use crate::message::NetMessage;
+use bincode::Options;
+
+pub const MAX_FRAME_SIZE: usize = 1024 * 1024; // 1 MB
 
 pub struct Encoder {
     output_buffer: Vec<u8>,
@@ -16,6 +20,101 @@ impl Encoder {
     }
 }
 
-pub fn decode<'a, M: Deserialize<'a>>(data_message: &'a [u8]) -> Option<M> {
-    bincode::deserialize::<M>(data_message).ok()
+pub fn decode(data_message: &[u8]) -> Option<NetMessage> {
+    if data_message.len() > MAX_FRAME_SIZE {
+        return None;
+    }
+    let options = bincode::options()
+        .with_limit(MAX_FRAME_SIZE as u64)
+        .with_fixint_encoding()
+        .allow_trailing_bytes();
+    let msg: NetMessage = options.deserialize(data_message).ok()?;
+    if msg.validate() {
+        Some(msg)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{AiPayload, Chunk, NetMessage, TodoItem, StructuredOutput};
+
+    #[test]
+    fn test_max_frame_size_rejection() {
+        let large_buffer = vec![0; MAX_FRAME_SIZE + 1];
+        let decoded: Option<NetMessage> = decode(&large_buffer);
+        assert!(decoded.is_none());
+    }
+
+    #[test]
+    fn test_valid_small_message() {
+        let msg = NetMessage::UserMessage("Hello".into());
+        let encoded = bincode::serialize(&msg).unwrap();
+        let decoded = decode(&encoded);
+        assert!(decoded.is_some());
+        if let Some(NetMessage::UserMessage(s)) = decoded {
+            assert_eq!(s, "Hello");
+        } else {
+            panic!("Expected UserMessage");
+        }
+    }
+
+    #[test]
+    fn test_oversized_chat_message() {
+        let msg = NetMessage::UserMessage("A".repeat(crate::message::MAX_CHAT_MESSAGE_LEN + 1));
+        let encoded = bincode::serialize(&msg).unwrap();
+        let decoded = decode(&encoded);
+        assert!(decoded.is_none(), "Should reject chat message exceeding max length");
+    }
+
+    #[test]
+    fn test_oversized_file_chunk() {
+        let bad_chunk = Chunk::Data(vec![0; crate::message::MAX_FILE_CHUNK_LEN + 1]);
+        let msg = NetMessage::UserData("file.txt".into(), bad_chunk);
+        let encoded = bincode::serialize(&msg).unwrap();
+        let decoded = decode(&encoded);
+        assert!(decoded.is_none(), "Should reject oversized file chunk");
+    }
+
+    #[test]
+    fn test_oversized_room_create_members() {
+        let members = vec!["user".into(); crate::message::MAX_ROOM_MEMBERS + 1];
+        let msg = NetMessage::RoomCreate("room1".into(), members);
+        let encoded = bincode::serialize(&msg).unwrap();
+        let decoded = decode(&encoded);
+        assert!(decoded.is_none(), "Should reject RoomCreate with too many members");
+    }
+
+    #[test]
+    fn test_oversized_ai_message_text() {
+        let payload = AiPayload {
+            text: "A".repeat(crate::message::MAX_AI_TEXT_LEN + 1),
+            intent: Default::default(),
+            structured: None,
+        };
+        let msg = NetMessage::AiMessage(payload);
+        let encoded = bincode::serialize(&msg).unwrap();
+        let decoded = decode(&encoded);
+        assert!(decoded.is_none(), "Should reject AI message with too long text");
+    }
+
+    #[test]
+    fn test_oversized_ai_structured_todos() {
+        let todos = vec![
+            TodoItem { text: "Todo".into(), assignee: None };
+            crate::message::MAX_TODO_ITEMS + 1
+        ];
+        let structured = StructuredOutput { todos, ..Default::default() };
+        let payload = AiPayload {
+            text: "Short text".into(),
+            intent: Default::default(),
+            structured: Some(structured),
+        };
+        let msg = NetMessage::AiMessage(payload);
+        let encoded = bincode::serialize(&msg).unwrap();
+        let decoded = decode(&encoded);
+        assert!(decoded.is_none(), "Should reject AI message with too many todo items");
+    }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -134,8 +134,7 @@ impl StructuredOutput {
 
 impl AiPayload {
     pub fn validate(&self) -> bool {
-        self.text.len() <= MAX_AI_TEXT_LEN
-            && self.structured.as_ref().is_none_or(|s| s.validate())
+        self.text.len() <= MAX_AI_TEXT_LEN && self.structured.as_ref().is_none_or(|s| s.validate())
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -95,3 +95,96 @@ pub enum NetMessage {
     RoomJoin(RoomId),
     SkillResult(SkillResultPayload),
 }
+
+pub const MAX_NAME_LEN: usize = 256;
+pub const MAX_CHAT_MESSAGE_LEN: usize = 65536; // 64 KB
+pub const MAX_FILE_NAME_LEN: usize = 256;
+pub const MAX_FILE_CHUNK_LEN: usize = 65536; // 64 KB
+pub const MAX_AI_TEXT_LEN: usize = 524288; // 512 KB
+pub const MAX_TODO_ITEMS: usize = 256;
+pub const MAX_TODO_TEXT_LEN: usize = 4096;
+pub const MAX_DECISIONS: usize = 256;
+pub const MAX_DECISION_TEXT_LEN: usize = 4096;
+pub const MAX_SKILL_SUGGESTIONS: usize = 256;
+pub const MAX_SKILL_NAME_LEN: usize = 128;
+pub const MAX_VERSION_LEN: usize = 64;
+pub const MAX_AVATAR_LEN: usize = 65536; // 64 KB
+pub const MAX_ROOM_ID_LEN: usize = 256;
+pub const MAX_ROOM_MEMBERS: usize = 256;
+pub const MAX_SKILL_SUMMARY_LEN: usize = 65536; // 64 KB
+
+impl TodoItem {
+    pub fn validate(&self) -> bool {
+        self.text.len() <= MAX_TODO_TEXT_LEN
+            && self.assignee.as_ref().is_none_or(|a| a.len() <= MAX_NAME_LEN)
+    }
+}
+
+impl StructuredOutput {
+    pub fn validate(&self) -> bool {
+        self.todos.len() <= MAX_TODO_ITEMS
+            && self.todos.iter().all(|t| t.validate())
+            && self.decisions.len() <= MAX_DECISIONS
+            && self.decisions.iter().all(|d| d.len() <= MAX_DECISION_TEXT_LEN)
+            && self.skill_suggestions.len() <= MAX_SKILL_SUGGESTIONS
+            && self.skill_suggestions.iter().all(|s| s.len() <= MAX_SKILL_NAME_LEN)
+            && self.raw_text.as_ref().is_none_or(|r| r.len() <= MAX_AI_TEXT_LEN)
+    }
+}
+
+impl AiPayload {
+    pub fn validate(&self) -> bool {
+        self.text.len() <= MAX_AI_TEXT_LEN
+            && self.structured.as_ref().is_none_or(|s| s.validate())
+    }
+}
+
+impl SkillResultPayload {
+    pub fn validate(&self) -> bool {
+        self.skill_name.len() <= MAX_SKILL_NAME_LEN && self.summary.len() <= MAX_SKILL_SUMMARY_LEN
+    }
+}
+
+impl PeerInfo {
+    pub fn validate(&self) -> bool {
+        self.user_name.len() <= MAX_NAME_LEN
+            && self.node_version.len() <= MAX_VERSION_LEN
+            && self.avatar.len() <= MAX_AVATAR_LEN
+    }
+}
+
+impl Chunk {
+    pub fn validate(&self) -> bool {
+        match self {
+            Chunk::Data(data) => data.len() <= MAX_FILE_CHUNK_LEN,
+            Chunk::Error | Chunk::End => true,
+        }
+    }
+}
+
+impl NetMessage {
+    pub fn validate(&self) -> bool {
+        match self {
+            NetMessage::HelloLan(name, _) => name.len() <= MAX_NAME_LEN,
+            NetMessage::HelloUser(name) => name.len() <= MAX_NAME_LEN,
+            NetMessage::UserMessage(msg) => msg.len() <= MAX_CHAT_MESSAGE_LEN,
+            NetMessage::UserData(filename, chunk) => {
+                filename.len() <= MAX_FILE_NAME_LEN && chunk.validate()
+            }
+            NetMessage::AiMessage(payload) => payload.validate(),
+            NetMessage::PeerInfo(info) => info.validate(),
+            NetMessage::RoomCreate(room_id, members) => {
+                room_id.len() <= MAX_ROOM_ID_LEN
+                    && members.len() <= MAX_ROOM_MEMBERS
+                    && members.iter().all(|m| m.len() <= MAX_NAME_LEN)
+            }
+            NetMessage::RoomCreateV2 { room_id, members, ai_mode: _ } => {
+                room_id.len() <= MAX_ROOM_ID_LEN
+                    && members.len() <= MAX_ROOM_MEMBERS
+                    && members.iter().all(|m| m.len() <= MAX_NAME_LEN)
+            }
+            NetMessage::RoomJoin(room_id) => room_id.len() <= MAX_ROOM_ID_LEN,
+            NetMessage::SkillResult(payload) => payload.validate(),
+        }
+    }
+}


### PR DESCRIPTION
Closes #81

### Refined Plan
1. Define limit constants for all components of `NetMessage` inside `src/message.rs`.
2. Implement validation checks (`validate` method) on `NetMessage` and sub-payloads.
3. Limit the incoming byte size in `encoder::decode` using a bounded bincode configuration (`options().with_limit()`).
4. Perform raw byte slice length check before deserializing in the network message receiver loop.
5. Log a warning system message on raw size limits or validation failures.

### Acceptance Criteria Checklist
- [x] Define explicit maximum sizes for inbound frames and high-risk payloads.
- [x] Reject oversized byte frames before calling `bincode::deserialize`.
- [x] Use bounded bincode options or equivalent checked decoding.
- [x] Add tests for oversized frame rejection and oversized `UserData`, `AiMessage`, and `RoomCreate` payloads.
- [x] Render a warning instead of crashing or allocating unbounded memory when a peer sends an oversized frame.

### Verification Evidence
- Full test suite passed (including 7 new unit tests for security boundary checking).
- Network integration tests successfully verified handshake and room creation stability.
