### PR TITLE
Reject unauthenticated peer traffic

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -17,6 +17,29 @@
 
 ---
 
+## GitHub Issue 対応履歴
+
+### Issue #90 — 未認証 peer の spoofing 拒否
+
+**ステータス:** `✅ Done`
+
+**変更ファイル:**
+```
+src/application/mod.rs
+src/state.rs
+tests/peer_trust_room_branches.rs
+docs/SPEC.md
+```
+
+**完了内容:**
+- [x] `UserMessage` と `UserData` を署名検証済み endpoint からのみ受理
+- [x] `AiMessage`, `RoomCreate`, `RoomCreateV2`, `RoomJoin`, `SkillResult` を署名検証済み endpoint からのみ受理
+- [x] 認証済み endpoint の `PeerInfo` identity 差し替えを拒否して切断
+- [x] 未認証 peer からの spoofed chat / room invite / AI output / skill result を拒否する regression test を追加
+- [x] TCP/UDP transport 暗号化は未実装の残リスクとして `docs/SPEC.md` に明記
+
+---
+
 ## 依存グラフ
 
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1009,10 +1009,13 @@ impl Default for LanguageConfig {
 ## 16. ネットワーク安全設計 (Phase 1)
 
 - デフォルト LAN 限定
-- 初回接続時に peer fingerprint `SHA256(user_name + node_version)` を保存
+- 初回接続時に `PeerIdentity` 署名を検証し、公開鍵 fingerprint を endpoint に紐づける
+- 署名検証後の endpoint が `PeerInfo` の `user_name`, `node_version`, `server_port` を変更した場合は切断する
+- peer 由来で state を変更する payload (`UserMessage`, `UserData`, `AiMessage`, `RoomCreate`, `RoomCreateV2`, `RoomJoin`, `SkillResult`) は署名検証済み endpoint からのみ受理する
 - `trusted_peers` に含まれる peer のみスキル実行を許可
 - `risk: medium|high` のスキルは明示承認が必要
 - Transcript はローカル保存のみ
+- TCP/UDP transport 自体はまだ暗号化されていない。LAN 上の盗聴対策には Noise/rustls 等の protocol upgrade が必要
 
 ---
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -352,19 +352,32 @@ impl<'a> Application<'a> {
                 self.ring_the_bell();
             }
             NetMessage::UserMessage(content) => {
-                if let Some(user) = self.state.user_name(endpoint) {
-                    self.state
-                        .add_message(ChatMessage::new(user.into(), MessageType::Text(content)));
+                if let Some(user) = self.state.user_name(endpoint).cloned() {
+                    if !self.accepts_authenticated_peer_message(endpoint, "message") {
+                        return;
+                    }
+                    self.state.add_message(ChatMessage::new(user, MessageType::Text(content)));
                     self.ring_the_bell();
                 }
             }
             NetMessage::UserData(file_name, chunk) => {
                 if let Some(user) = self.state.user_name(endpoint).cloned() {
+                    if !self.accepts_authenticated_peer_message(endpoint, "file transfer") {
+                        return;
+                    }
                     self.process_user_data(&user, &file_name, chunk);
                 }
             }
-            NetMessage::AiMessage(payload) => self.process_remote_ai_response(endpoint, payload),
+            NetMessage::AiMessage(payload) => {
+                if !self.accepts_authenticated_peer_message(endpoint, "AI message") {
+                    return;
+                }
+                self.process_remote_ai_response(endpoint, payload);
+            }
             NetMessage::PeerInfo(peer) => {
+                if self.rejects_authenticated_peer_identity_change(endpoint, &peer) {
+                    return;
+                }
                 self.state.connected_user(endpoint, &peer.user_name);
                 self.state.record_peer(endpoint, peer.clone());
                 if !version_supports_peer_identity(&peer.node_version) {
@@ -488,6 +501,9 @@ impl<'a> Application<'a> {
                 ));
             }
             NetMessage::RoomCreate(room_id, member_ids) => {
+                if !self.accepts_authenticated_peer_message(endpoint, "room invite") {
+                    return;
+                }
                 if member_ids.iter().any(|member_id| member_id == &self.config.user_name) {
                     let room = self.state.accept_room(&room_id, &member_ids, None);
                     self.state.add_system_info_message(format!("joined room {}", room.id));
@@ -497,6 +513,9 @@ impl<'a> Application<'a> {
                 }
             }
             NetMessage::RoomCreateV2 { room_id, members, ai_mode } => {
+                if !self.accepts_authenticated_peer_message(endpoint, "room invite") {
+                    return;
+                }
                 if members.iter().any(|member_id| member_id == &self.config.user_name) {
                     let room = self.state.accept_room(&room_id, &members, ai_mode);
                     self.state.add_system_info_message(format!("joined room {}", room.id));
@@ -506,11 +525,63 @@ impl<'a> Application<'a> {
                 }
             }
             NetMessage::RoomJoin(room_id) => {
+                if !self.accepts_authenticated_peer_message(endpoint, "room join") {
+                    return;
+                }
                 let _ = self.state.switch_room(&room_id);
                 self.state.add_system_info_message(format!("room {} is ready", room_id));
             }
-            NetMessage::SkillResult(payload) => self.record_skill_done(payload, false),
+            NetMessage::SkillResult(payload) => {
+                if !self.accepts_authenticated_peer_message(endpoint, "skill result") {
+                    return;
+                }
+                self.record_skill_done(payload, false);
+            }
         }
+    }
+
+    fn rejects_authenticated_peer_identity_change(
+        &mut self,
+        endpoint: Endpoint,
+        next_peer: &PeerInfo,
+    ) -> bool {
+        if !self.state.is_peer_authenticated_endpoint(endpoint) {
+            return false;
+        }
+        let Some(current_peer) = self.state.peers().get(&endpoint).cloned() else {
+            return false;
+        };
+        if current_peer.user_name == next_peer.user_name
+            && current_peer.node_version == next_peer.node_version
+            && current_peer.server_port == next_peer.server_port
+        {
+            return false;
+        }
+        self.state.add_system_error_message(format!(
+            "Security warning: authenticated peer {} attempted to change identity to {}. Disconnecting.",
+            current_peer.user_name, next_peer.user_name
+        ));
+        self.node.network().remove(endpoint.resource_id());
+        self.state.disconnected_user(endpoint);
+        true
+    }
+
+    fn accepts_authenticated_peer_message(
+        &mut self,
+        endpoint: Endpoint,
+        message_kind: &str,
+    ) -> bool {
+        let Some(user) = self.state.user_name(endpoint).map(|user| user.to_string()) else {
+            return false;
+        };
+        if self.state.is_peer_authenticated_endpoint(endpoint) {
+            return true;
+        }
+        self.state.add_system_warn_message(format!(
+            "rejected unauthenticated {} from {}",
+            message_kind, user
+        ));
+        false
     }
 
     fn process_terminal_event(&mut self, term_event: TermEvent) -> Result<()> {
@@ -1241,6 +1312,10 @@ impl<'a> Application<'a> {
         };
 
         self.state.record_peer(endpoint, peer);
+        self.state.add_verified_peer_fingerprint(endpoint, fingerprint.to_string());
+    }
+
+    pub fn authenticate_endpoint_for_test(&mut self, endpoint: Endpoint, fingerprint: &str) {
         self.state.add_verified_peer_fingerprint(endpoint, fingerprint.to_string());
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -695,6 +695,10 @@ impl State {
         }
     }
 
+    pub fn is_peer_authenticated_endpoint(&self, endpoint: Endpoint) -> bool {
+        self.verified_peer_fingerprints.contains_key(&endpoint)
+    }
+
     pub fn peer_readiness(&self, endpoint: Endpoint) -> PeerReadiness {
         self.peers.get(&endpoint).map(peer_readiness).unwrap_or(PeerReadiness::Connecting)
     }

--- a/tests/peer_trust_room_branches.rs
+++ b/tests/peer_trust_room_branches.rs
@@ -6,7 +6,7 @@ use tempfile::TempDir;
 
 use triadchat::application::Application;
 use triadchat::config::Config;
-use triadchat::message::{NetMessage, PeerInfo};
+use triadchat::message::{AiIntent, AiPayload, Chunk, NetMessage, PeerInfo, SkillResultPayload};
 use triadchat::state::{peer_fingerprint, State};
 
 fn make_test_config(dir: &TempDir) -> Config {
@@ -121,6 +121,8 @@ fn room_create_includes_local_joins() {
     let (mut app, listener) = make_app(&config);
 
     let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+    app.authenticate_endpoint_for_test(endpoint, "fp:tanaka:test");
     let room_id = "room-1".to_string();
     let member_ids = vec!["tester".to_string(), "tanaka".to_string()];
     app.inject_network_message_for_test(
@@ -131,6 +133,173 @@ fn room_create_includes_local_joins() {
     let rendered = rendered_messages(app.state());
     assert_contains(&rendered, &format!("joined room {}", room_id));
     assert_eq!(app.state().active_room_id(), Some(room_id.as_str()));
+}
+
+#[test]
+fn unauthenticated_peer_message_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+
+    app.inject_network_message_for_test(
+        endpoint,
+        NetMessage::UserMessage("spoofed message".to_string()),
+    );
+
+    let rendered = rendered_messages(app.state());
+    assert_not_contains(&rendered, "spoofed message");
+    assert_contains(&rendered, "rejected unauthenticated message from tanaka");
+}
+
+#[test]
+fn unauthenticated_peer_file_transfer_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+
+    app.inject_network_message_for_test(
+        endpoint,
+        NetMessage::UserData("spoofed.txt".to_string(), Chunk::Data(b"payload".to_vec())),
+    );
+
+    let rendered = rendered_messages(app.state());
+    assert_contains(&rendered, "rejected unauthenticated file transfer from tanaka");
+}
+
+#[test]
+fn unauthenticated_peer_room_create_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+
+    app.inject_network_message_for_test(
+        endpoint,
+        NetMessage::RoomCreate("room-spoof".to_string(), vec!["tester".to_string()]),
+    );
+
+    let rendered = rendered_messages(app.state());
+    assert_not_contains(&rendered, "joined room room-spoof");
+    assert_contains(&rendered, "rejected unauthenticated room invite from tanaka");
+    assert_eq!(app.state().active_room_id(), None);
+}
+
+#[test]
+fn unauthenticated_peer_room_create_v2_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+
+    app.inject_network_message_for_test(
+        endpoint,
+        NetMessage::RoomCreateV2 {
+            room_id: "room-spoof-v2".to_string(),
+            members: vec!["tester".to_string()],
+            ai_mode: None,
+        },
+    );
+
+    let rendered = rendered_messages(app.state());
+    assert_not_contains(&rendered, "joined room room-spoof-v2");
+    assert_contains(&rendered, "rejected unauthenticated room invite from tanaka");
+    assert_eq!(app.state().active_room_id(), None);
+}
+
+#[test]
+fn unauthenticated_peer_room_join_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+
+    app.inject_network_message_for_test(endpoint, NetMessage::RoomJoin("room-spoof".to_string()));
+
+    let rendered = rendered_messages(app.state());
+    assert_not_contains(&rendered, "room room-spoof is ready");
+    assert_contains(&rendered, "rejected unauthenticated room join from tanaka");
+}
+
+#[test]
+fn unauthenticated_peer_ai_message_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+
+    app.inject_network_message_for_test(
+        endpoint,
+        NetMessage::AiMessage(AiPayload {
+            text: "spoofed ai output".to_string(),
+            intent: AiIntent::Summary,
+            structured: None,
+        }),
+    );
+
+    let rendered = rendered_messages(app.state());
+    assert_not_contains(&rendered, "spoofed ai output");
+    assert_contains(&rendered, "rejected unauthenticated AI message from tanaka");
+}
+
+#[test]
+fn authenticated_peer_identity_change_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+    app.authenticate_endpoint_for_test(endpoint, "fp:tanaka:test");
+
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("sato")));
+    app.inject_network_message_for_test(
+        endpoint,
+        NetMessage::UserMessage("spoofed identity message".to_string()),
+    );
+
+    let rendered = rendered_messages(app.state());
+    assert_contains(
+        &rendered,
+        "Security warning: authenticated peer tanaka attempted to change identity to sato. Disconnecting.",
+    );
+    assert_not_contains(&rendered, "spoofed identity message");
+}
+
+#[test]
+fn unauthenticated_peer_skill_result_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let config = make_test_config(&dir);
+    let (mut app, listener) = make_app(&config);
+
+    let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+
+    app.inject_network_message_for_test(
+        endpoint,
+        NetMessage::SkillResult(SkillResultPayload {
+            skill_name: "review-auth".to_string(),
+            summary: "spoofed skill result".to_string(),
+            success: true,
+        }),
+    );
+
+    let rendered = rendered_messages(app.state());
+    assert_not_contains(&rendered, "spoofed skill result");
+    assert_contains(&rendered, "rejected unauthenticated skill result from tanaka");
 }
 
 #[test]
@@ -159,6 +328,8 @@ fn room_join_switches_and_emits_ready() {
     let (mut app, listener) = make_app(&config);
 
     let endpoint = app.connect_raw_for_test(listener.local_addr().unwrap()).unwrap();
+    app.inject_network_message_for_test(endpoint, NetMessage::PeerInfo(peer_info("tanaka")));
+    app.authenticate_endpoint_for_test(endpoint, "fp:tanaka:test");
 
     let room_id = "room-3".to_string();
     let member_ids = vec!["tester".to_string(), "tanaka".to_string()];


### PR DESCRIPTION
## Summary
- Addresses the spoofing mitigation in #90 by requiring peer authentication before applying peer-originated state-changing messages.
- Rejects unauthenticated UserMessage, UserData, AiMessage, RoomCreate, RoomCreateV2, RoomJoin, and SkillResult payloads.
- Disconnects an already-authenticated endpoint that attempts to mutate its advertised PeerInfo identity.
- Updates SPEC/PLAN with the enforced authentication boundary and the remaining plaintext transport risk.

## Acceptance Criteria
- [x] Unauthenticated chat messages are not rendered.
- [x] Unauthenticated file-transfer chunks are not processed.
- [x] Unauthenticated room invites and room joins are ignored.
- [x] Unauthenticated remote AI output and skill results are ignored.
- [x] Authenticated endpoint identity changes are rejected and disconnected.
- [x] Existing authenticated peer handshake and room creation still work.

## Review Notes
- Reviewer finding: endpoint-only authentication still allowed an authenticated endpoint to swap PeerInfo identity. Fixed by rejecting identity mutation after authentication.
- Reviewer finding: missing regression coverage for UserData, RoomCreateV2, and RoomJoin. Added tests for all three paths.

## Verification
- cargo test --test peer_trust_room_branches
- cargo test --test network_integration
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- cargo audit (exit 0; existing allowed warnings: bincode RUSTSEC-2025-0141, paste RUSTSEC-2024-0436, lru RUSTSEC-2026-0002, rand RUSTSEC-2026-0097)

## Residual Risk
- This does not add Noise/rustls encryption for TCP/UDP transport. LAN traffic confidentiality remains a separate protocol-upgrade task, documented in docs/SPEC.md.

Addresses #90