### PR TITLE
feat: dynamic AI provider switching via /ai provider (#93 part 1)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -896,12 +896,15 @@ Layout::horizontal([
 /ai mode <listener|clerk|moderator|operator>
 /ai quiet <on|off>
 /ai freq <low|normal|high>
+/ai provider <claude|codex|gemini|custom>
 
 /summary          直近会話の要約
 /todos            TODO 一覧
 /decisions        決定事項一覧
 /context          会話コンテキスト全体
 ```
+
+`/ai provider` は実行中の AI エンジンを動的に切り替える。`SidecarAdapter` が新しいプロバイダーのコマンド (`which` または `ai.command`) を解決できた時点で `state.ai_provider` と `ai_mediator` を置き換える。解決に失敗した場合は以前のプロバイダーと mediator を維持し、エラーメッセージを表示する。
 
 ### Phase 1 追加コマンド
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -903,6 +903,33 @@ impl<'a> Application<'a> {
                     ai_frequency_label(&self.state.ai_frequency)
                 ));
             }
+            AppCommand::SetAiProvider(provider) => {
+                let workspace = match std::env::current_dir() {
+                    Ok(dir) => dir,
+                    Err(error) => {
+                        self.state.add_system_error_message(format!(
+                            "Failed to resolve workspace for AI provider switch: {error}"
+                        ));
+                        return;
+                    }
+                };
+                let mut ai_config = self.config.ai.clone();
+                ai_config.provider = provider;
+                match AiMediator::new(&workspace, &ai_config, &self.config.language) {
+                    Ok(mediator) => {
+                        let label = ai_config.provider.label().to_string();
+                        self.state.ai_provider = ai_config.provider;
+                        self.ai_mediator = Some(Arc::new(mediator));
+                        self.state.ai_state = AiState::Idle;
+                        self.state.add_system_info_message(format!("AI provider set to {label}"));
+                    }
+                    Err(error) => {
+                        self.state.add_system_error_message(format!(
+                            "Failed to set AI provider: {error}"
+                        ));
+                    }
+                }
+            }
             AppCommand::RoomCreate { peers, ai_mode } => {
                 if let Some(missing_peer) = peers
                     .iter()
@@ -1981,6 +2008,7 @@ fn help_text() -> String {
                 ("", "  companion  Casual conversational partner"),
                 ("/ai quiet <on|off>", "Mute/unmute AI responses"),
                 ("/ai freq <low|normal|high>", "Adjust AI intervention frequency"),
+                ("/ai provider <provider>", "Switch AI engine (claude, gemini, codex, custom)"),
             ],
         ),
         (

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -68,6 +68,7 @@ pub struct Application<'a> {
     encoder: Encoder,
     runtime: tokio::runtime::Runtime,
     ai_mediator: Option<Arc<AiMediator>>,
+    workspace: PathBuf,
     avatar_manager: AvatarManager,
     art_dict: HashMap<String, String>,
     art_yaml_path: Option<PathBuf>,
@@ -201,6 +202,7 @@ impl<'a> Application<'a> {
             encoder: Encoder::new(),
             runtime,
             ai_mediator,
+            workspace: workspace.to_path_buf(),
             avatar_manager,
             art_dict,
             art_yaml_path,
@@ -904,18 +906,23 @@ impl<'a> Application<'a> {
                 ));
             }
             AppCommand::SetAiProvider(provider) => {
-                let workspace = match std::env::current_dir() {
-                    Ok(dir) => dir,
-                    Err(error) => {
-                        self.state.add_system_error_message(format!(
-                            "Failed to resolve workspace for AI provider switch: {error}"
-                        ));
-                        return;
-                    }
-                };
+                if !self.config.ai.enabled {
+                    self.state.add_system_error_message(
+                        "AI is disabled in config; cannot switch provider.".into(),
+                    );
+                    return;
+                }
+                if self.state.ai_thinking {
+                    self.state.add_system_error_message(
+                        "Cannot switch AI provider while a request is in flight; wait for it to \
+                         finish."
+                            .into(),
+                    );
+                    return;
+                }
                 let mut ai_config = self.config.ai.clone();
                 ai_config.provider = provider;
-                match AiMediator::new(&workspace, &ai_config, &self.config.language) {
+                match AiMediator::new(&self.workspace, &ai_config, &self.config.language) {
                     Ok(mediator) => {
                         let label = ai_config.provider.label().to_string();
                         self.state.ai_provider = ai_config.provider;
@@ -1443,6 +1450,10 @@ impl<'a> Application<'a> {
 
     pub fn state(&self) -> &State {
         &self.state
+    }
+
+    pub fn set_ai_thinking_for_test(&mut self, thinking: bool) {
+        self.state.ai_thinking = thinking;
     }
 
     pub fn has_secure_session(&self, endpoint: Endpoint) -> bool {
@@ -2008,7 +2019,7 @@ fn help_text() -> String {
                 ("", "  companion  Casual conversational partner"),
                 ("/ai quiet <on|off>", "Mute/unmute AI responses"),
                 ("/ai freq <low|normal|high>", "Adjust AI intervention frequency"),
-                ("/ai provider <provider>", "Switch AI engine (claude, gemini, codex, custom)"),
+                ("/ai provider <provider>", "Switch AI engine (claude, codex, gemini, custom)"),
             ],
         ),
         (

--- a/src/commands/ai_cmd.rs
+++ b/src/commands/ai_cmd.rs
@@ -1,4 +1,5 @@
 use crate::commands::{AppCommand, Command, ParsedCommand};
+use crate::config::AiProvider;
 use crate::state::{AiFrequency, AiMode};
 use crate::util::Result;
 
@@ -33,8 +34,16 @@ impl Command for AiCommand {
                     parse_frequency(params.get(1).map(String::as_str).unwrap_or("normal"))?;
                 Ok(ParsedCommand::App(AppCommand::SetAiFrequency(frequency)))
             }
+            "provider" => {
+                let provider = params
+                    .get(1)
+                    .map(String::as_str)
+                    .unwrap_or("claude")
+                    .parse::<AiProvider>()?;
+                Ok(ParsedCommand::App(AppCommand::SetAiProvider(provider)))
+            }
             _ => Err(anyhow::anyhow!(
-                "usage: /ai mode <mode>\n  clerk      - responds to decisions and task markers\n  listener   - silent; never auto-intervenes\n  moderator  - intervenes on ambiguous or contradictory messages\n  operator   - responds to execute, deploy, or run requests\n  companion  - chats actively and replies to direct prompts\nusage: /ai quiet <on|off>\nusage: /ai freq <low|normal|high>"
+                "usage: /ai mode <mode>\n  clerk      - responds to decisions and task markers\n  listener   - silent; never auto-intervenes\n  moderator  - intervenes on ambiguous or contradictory messages\n  operator   - responds to execute, deploy, or run requests\n  companion  - chats actively and replies to direct prompts\nusage: /ai quiet <on|off>\nusage: /ai freq <low|normal|high>\nusage: /ai provider <claude|codex|gemini|custom>"
             )),
         }
     }
@@ -80,5 +89,34 @@ mod tests {
         assert!(error.to_string().contains("listener"));
         assert!(error.to_string().contains("moderator"));
         assert!(error.to_string().contains("operator"));
+    }
+
+    #[test]
+    fn parse_params_provider_returns_provider() {
+        let parsed = AiCommand
+            .parse_params(vec!["provider".into(), "gemini".into()])
+            .expect("gemini is a valid AI provider");
+
+        assert!(matches!(
+            parsed,
+            ParsedCommand::App(AppCommand::SetAiProvider(AiProvider::Gemini))
+        ));
+    }
+
+    #[test]
+    fn parse_params_provider_unknown_returns_error() {
+        assert!(AiCommand.parse_params(vec!["provider".into(), "openai".into()]).is_err());
+    }
+
+    #[test]
+    fn parse_params_provider_defaults_to_claude() {
+        let parsed = AiCommand
+            .parse_params(vec!["provider".into()])
+            .expect("provider with no arg defaults to claude");
+
+        assert!(matches!(
+            parsed,
+            ParsedCommand::App(AppCommand::SetAiProvider(AiProvider::Claude))
+        ));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod summary_cmd;
 use std::collections::HashMap;
 
 use crate::action::Action;
+use crate::config::AiProvider;
 use crate::state::{AiFrequency, AiMode};
 use crate::util::Result;
 
@@ -42,6 +43,7 @@ pub enum AppCommand {
     SetAiMode(AiMode),
     SetAiQuiet(bool),
     SetAiFrequency(AiFrequency),
+    SetAiProvider(AiProvider),
     RoomCreate { peers: Vec<String>, ai_mode: Option<AiMode> },
     RoomList,
     RoomSwitch(String),

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,20 @@ pub enum AiProvider {
     Custom,
 }
 
+impl std::str::FromStr for AiProvider {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        match s.to_lowercase().as_str() {
+            "claude" => Ok(Self::Claude),
+            "codex" => Ok(Self::Codex),
+            "gemini" => Ok(Self::Gemini),
+            "custom" => Ok(Self::Custom),
+            other => Err(anyhow::anyhow!("unknown AI provider: {other}")),
+        }
+    }
+}
+
 impl AiProvider {
     pub fn invocation(&self) -> (&'static str, &'static [&'static str]) {
         match self {
@@ -231,6 +245,21 @@ mod tests {
     #[test]
     fn ai_config_defaults_to_claude_provider() {
         assert_eq!(AiConfig::default().provider, AiProvider::Claude);
+    }
+
+    #[test]
+    fn ai_provider_from_str_accepts_all_known_variants() {
+        assert_eq!("claude".parse::<AiProvider>().unwrap(), AiProvider::Claude);
+        assert_eq!("CLAUDE".parse::<AiProvider>().unwrap(), AiProvider::Claude);
+        assert_eq!("codex".parse::<AiProvider>().unwrap(), AiProvider::Codex);
+        assert_eq!("gemini".parse::<AiProvider>().unwrap(), AiProvider::Gemini);
+        assert_eq!("custom".parse::<AiProvider>().unwrap(), AiProvider::Custom);
+    }
+
+    #[test]
+    fn ai_provider_from_str_rejects_unknown() {
+        assert!("openai".parse::<AiProvider>().is_err());
+        assert!("wat".parse::<AiProvider>().is_err());
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,7 +185,7 @@ impl std::str::FromStr for AiProvider {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
-        match s.to_lowercase().as_str() {
+        match s.to_ascii_lowercase().as_str() {
             "claude" => Ok(Self::Claude),
             "codex" => Ok(Self::Codex),
             "gemini" => Ok(Self::Gemini),

--- a/tests/phase0_commands_e2e.rs
+++ b/tests/phase0_commands_e2e.rs
@@ -5,7 +5,7 @@ mod common;
 use common::{config_with_ai_script, rendered_messages, write_executable_script};
 use triadchat::application::Application;
 use triadchat::config::{AiProvider, Config};
-use triadchat::state::{AiMode, MessageType};
+use triadchat::state::{AiMode, AiState, MessageType};
 
 #[test]
 fn summary_commands_and_auto_intervention_work_end_to_end() {
@@ -163,28 +163,72 @@ fn ai_provider_command_switches_active_provider() {
     app.handle_input_line_for_test("/ai provider gemini").unwrap();
 
     assert_eq!(app.state().ai_provider, AiProvider::Gemini);
+    assert_eq!(app.state().ai_state, AiState::Idle);
     assert!(!app.state().ai_thinking);
     let rendered = rendered_messages(&app);
     assert!(rendered.contains("AI provider set to gemini"));
 }
 
 #[test]
-fn ai_provider_command_failure_keeps_previous_provider() {
+fn ai_provider_command_refused_while_ai_thinking() {
+    let dir = TempDir::new().unwrap();
+    let script =
+        write_executable_script(dir.path(), "mock-claude.sh", "#!/bin/sh\nprintf 'noop\n'");
+    let config = config_with_ai_script(&script, "takuro");
+    let mut app = Application::new_for_test(&config).unwrap();
+
+    app.set_ai_thinking_for_test(true);
+
+    app.handle_input_line_for_test("/ai provider gemini").unwrap();
+
+    // State must be untouched.
+    assert_eq!(app.state().ai_provider, AiProvider::Claude);
+    assert!(app.state().ai_thinking);
+    let rendered = rendered_messages(&app);
+    assert!(rendered.contains("Cannot switch AI provider while a request is in flight"));
+    assert!(!rendered.contains("AI provider set to gemini"));
+}
+
+#[test]
+fn ai_provider_command_refused_when_ai_disabled_in_config() {
     let mut config = Config::default();
     config.ai.enabled = false;
     let mut app = Application::new_for_test(&config).unwrap();
 
     assert_eq!(app.state().ai_provider, AiProvider::Claude);
 
-    // `custom` provider without a configured command deterministically fails
-    // inside SidecarAdapter::new, so we can assert the rollback behaviour
-    // without depending on what binaries happen to be on PATH.
-    app.handle_input_line_for_test("/ai provider custom").unwrap();
+    app.handle_input_line_for_test("/ai provider gemini").unwrap();
+
+    assert_eq!(app.state().ai_provider, AiProvider::Claude);
+    let rendered = rendered_messages(&app);
+    assert!(rendered.contains("AI is disabled in config; cannot switch provider"));
+    assert!(!rendered.contains("AI provider set to gemini"));
+}
+
+#[test]
+fn ai_provider_command_failure_keeps_previous_provider() {
+    // Initial config has a real script, so AiMediator builds on construction.
+    let script_dir = TempDir::new().unwrap();
+    let script =
+        write_executable_script(script_dir.path(), "mock-claude.sh", "#!/bin/sh\nprintf 'noop\n'");
+    let mut config = Config::default();
+    config.ai.enabled = true;
+    config.ai.command = Some(script.display().to_string());
+    let mut app = Application::new_for_test(&config).unwrap();
+    assert_eq!(app.state().ai_provider, AiProvider::Claude);
+
+    // Drop the script dir so the command path no longer resolves. The handler
+    // clones self.config.ai and re-checks command existence inside
+    // SidecarAdapter::new, so the switch deterministically fails here without
+    // depending on what provider binaries happen to be on PATH.
+    drop(script_dir);
+
+    app.handle_input_line_for_test("/ai provider gemini").unwrap();
 
     assert_eq!(app.state().ai_provider, AiProvider::Claude);
     let rendered = rendered_messages(&app);
     assert!(rendered.contains("Failed to set AI provider"));
-    assert!(!rendered.contains("AI provider set to custom"));
+    assert!(!rendered.contains("AI provider set to gemini"));
 }
 
 #[test]

--- a/tests/phase0_commands_e2e.rs
+++ b/tests/phase0_commands_e2e.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::{config_with_ai_script, rendered_messages, write_executable_script};
 use triadchat::application::Application;
-use triadchat::config::Config;
+use triadchat::config::{AiProvider, Config};
 use triadchat::state::{AiMode, MessageType};
 
 #[test]
@@ -124,6 +124,7 @@ fn help_command_groups_commands_with_descriptions() {
     assert!(rendered.contains("Set avatar (target: self, @ops-ai)"));
     assert!(rendered.contains("Send a file to peers in the room"));
     assert!(rendered.contains("/ai mode <mode>"));
+    assert!(rendered.contains("/ai provider <provider>"));
     assert!(rendered.contains("/room switch <id|name>"));
     assert!(rendered.contains("Switch active room"));
     assert!(rendered.contains("/peer connect <host:port>"));
@@ -147,6 +148,61 @@ fn ai_commands_report_human_readable_feedback() {
 
     assert!(rendered.contains("AI mode set to moderator"));
     assert!(rendered.contains("AI frequency set to low"));
+}
+
+#[test]
+fn ai_provider_command_switches_active_provider() {
+    let dir = TempDir::new().unwrap();
+    let script =
+        write_executable_script(dir.path(), "mock-claude.sh", "#!/bin/sh\nprintf 'noop\n'");
+    let config = config_with_ai_script(&script, "takuro");
+    let mut app = Application::new_for_test(&config).unwrap();
+
+    assert_eq!(app.state().ai_provider, AiProvider::Claude);
+
+    app.handle_input_line_for_test("/ai provider gemini").unwrap();
+
+    assert_eq!(app.state().ai_provider, AiProvider::Gemini);
+    assert!(!app.state().ai_thinking);
+    let rendered = rendered_messages(&app);
+    assert!(rendered.contains("AI provider set to gemini"));
+}
+
+#[test]
+fn ai_provider_command_failure_keeps_previous_provider() {
+    let mut config = Config::default();
+    config.ai.enabled = false;
+    let mut app = Application::new_for_test(&config).unwrap();
+
+    assert_eq!(app.state().ai_provider, AiProvider::Claude);
+
+    // `custom` provider without a configured command deterministically fails
+    // inside SidecarAdapter::new, so we can assert the rollback behaviour
+    // without depending on what binaries happen to be on PATH.
+    app.handle_input_line_for_test("/ai provider custom").unwrap();
+
+    assert_eq!(app.state().ai_provider, AiProvider::Claude);
+    let rendered = rendered_messages(&app);
+    assert!(rendered.contains("Failed to set AI provider"));
+    assert!(!rendered.contains("AI provider set to custom"));
+}
+
+#[test]
+fn ai_provider_command_defaults_to_claude_when_omitted() {
+    let dir = TempDir::new().unwrap();
+    let script =
+        write_executable_script(dir.path(), "mock-claude.sh", "#!/bin/sh\nprintf 'noop\n'");
+    let config = config_with_ai_script(&script, "takuro");
+    let mut app = Application::new_for_test(&config).unwrap();
+
+    app.handle_input_line_for_test("/ai provider gemini").unwrap();
+    assert_eq!(app.state().ai_provider, AiProvider::Gemini);
+
+    app.handle_input_line_for_test("/ai provider").unwrap();
+
+    assert_eq!(app.state().ai_provider, AiProvider::Claude);
+    let rendered = rendered_messages(&app);
+    assert!(rendered.contains("AI provider set to claude"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements Part 1 of #93: dynamic AI engine switching at runtime via `/ai provider <claude|codex|gemini|custom>`.

Users can switch the active AI sidecar without restart. The previous provider and mediator are preserved when the new provider's binary cannot be resolved, so a missing binary never silently disables AI.

Part 2 (file-transfer progress bar) is intentionally out of scope and will be tracked separately.

## Plan / Acceptance Criteria

- [x] New `/ai provider <X>` command parses all four providers and rejects unknown names.
- [x] `Application` rebuilds `AiMediator` with the new provider config at runtime.
- [x] State is mutated **only after** the new `SidecarAdapter` resolves successfully (correctness fix — the in-progress draft mutated `state.ai_provider` before validation and forced `AiState::Disabled` on failure).
- [x] `current_dir()` no longer uses `.expect()` (No Unwraps rule).
- [x] `/help` lists the new command.
- [x] SPEC.md Phase 0 command block documents the command and rollback semantics.

## Verification (local — matches CI commands exactly)

```
cargo fmt --all -- --check              ✅ clean
cargo clippy --all-targets -- -D warnings   ✅ no warnings
cargo test --tests                       ✅ all green
cargo build --release                    ✅ success
```

New/changed tests in `tests/phase0_commands_e2e.rs`:
- `ai_provider_command_switches_active_provider` — happy path (Claude → Gemini)
- `ai_provider_command_failure_keeps_previous_provider` — rollback when `custom` provider has no command (deterministic; no PATH dependency)
- `ai_provider_command_defaults_to_claude_when_omitted` — bare `/ai provider` defaults to Claude
- `help_command_groups_commands_with_descriptions` — extended to assert `/ai provider <provider>` is listed

Existing unit tests in `src/commands/ai_cmd.rs` and `src/config.rs` cover parsing and `AiProvider::FromStr` for all variants (case-insensitive) plus rejection of unknown providers.

## Files changed

- `src/commands/ai_cmd.rs` — parser branch + 3 unit tests (from in-progress work)
- `src/commands/mod.rs` — `AppCommand::SetAiProvider(AiProvider)` variant
- `src/config.rs` — `AiProvider::FromStr` + 2 unit tests
- `src/application/mod.rs` — runtime handler (correctness fix + No-Unwraps fix) + help text
- `tests/phase0_commands_e2e.rs` — 3 new integration tests + help assertion
- `docs/SPEC.md` — Phase 0 command list updated

## Risks

- Switching to a provider whose binary is not on PATH (and no `ai.command` override) reports an error and keeps the prior provider. This is the intended UX; users are never left with a disabled AI due to a typo.
- No persistence to `config.toml` — runtime-only, matching Issue language ("dynamically during runtime"). Persistence can be added later if desired.

## Out of scope

#93 Part 2 (file-transfer progress bar) — separate issue/PR.

Closes #93 (Part 1).