### PR TITLE
security/ux: add transfer offer, accept/reject, and size controls for inbound file transfers (#103)

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -25,6 +25,7 @@ use crate::commands::room_cmd::{PeersCommand, RoomCommand};
 use crate::commands::send_file::SendFileCommand;
 use crate::commands::skill_cmd::{CancelCommand, RunCommand, SkillCommand, SkillsCommand};
 use crate::commands::summary_cmd::SummaryCommand;
+use crate::commands::transfer_cmd::{AcceptCommand, RejectCommand};
 use crate::commands::{
     AppCommand, AvatarCommandKind, CommandManager, ParsedCommand, SummaryCommandKind,
 };
@@ -38,8 +39,8 @@ use crate::room::{MemberKind, Room};
 use crate::renderer::Renderer;
 use crate::secure::SecureState;
 use crate::state::{
-    AiFrequency, AiMode, AiState, ChatMessage, CursorMovement, MessageType, ScrollMovement, State,
-    PeerReadiness,
+    AiFrequency, AiMode, AiState, ChatMessage, CursorMovement, MessageType, PeerReadiness,
+    PendingTransferOffer, ScrollMovement, State,
 };
 use crate::skill::executor::{PendingSkillExecution, SkillExecutor};
 use crate::skill::registry::{InvokeMode, RiskLevel};
@@ -136,7 +137,9 @@ impl<'a> Application<'a> {
             .with(SummaryCommand::decisions())
             .with(SummaryCommand::context())
             .with(AvatarCommand)
-            .with(ArtCommand);
+            .with(ArtCommand)
+            .with(AcceptCommand)
+            .with(RejectCommand);
         let runtime = tokio::runtime::Runtime::new()?;
 
         let mut state = State::default();
@@ -556,6 +559,18 @@ impl<'a> Application<'a> {
             }
             NetMessage::Secure(encrypted) => {
                 self.process_secure_message(endpoint, encrypted);
+            }
+            NetMessage::TransferOffer { file_name, file_size, sender } => {
+                self.process_transfer_offer(endpoint, file_name, file_size, sender);
+            }
+            NetMessage::TransferAccept { file_name } => {
+                self.process_transfer_accept(endpoint, file_name);
+            }
+            NetMessage::TransferReject { file_name, reason } => {
+                self.process_transfer_reject(endpoint, file_name, reason);
+            }
+            NetMessage::TransferCancel { file_name } => {
+                self.process_transfer_cancel(endpoint, file_name);
             }
         }
     }
@@ -1155,6 +1170,8 @@ impl<'a> Application<'a> {
                 self.queue_or_run_skill(proposal.skill_name, Vec::new());
             }
             AppCommand::Cancel => self.cancel_active_task(),
+            AppCommand::AcceptTransfer(filename) => self.accept_transfer(filename),
+            AppCommand::RejectTransfer(filename) => self.reject_transfer(filename),
             AppCommand::Avatar(kind) => self.process_avatar_command(kind),
             AppCommand::ArtList => {
                 if self.art_dict.is_empty() {
@@ -1548,6 +1565,138 @@ impl<'a> Application<'a> {
         self.state.add_verified_peer_fingerprint(endpoint, fingerprint.to_string());
     }
 
+    fn process_transfer_offer(
+        &mut self,
+        endpoint: Endpoint,
+        file_name: String,
+        file_size: u64,
+        sender: String,
+    ) {
+        if !self.accepts_authenticated_peer_message(endpoint, "transfer offer") {
+            let _ = self.state.user_name(endpoint).map(|u| u.to_string());
+            return;
+        }
+        if file_size > crate::message::MAX_TRANSFER_SIZE {
+            self.state.add_system_warn_message(format!(
+                "transfer offer from {} for '{}' rejected: {} exceeds max {}",
+                sender,
+                file_name,
+                file_size,
+                crate::message::MAX_TRANSFER_DISPLAY_NAME,
+            ));
+            self.send_secure_to_peer(
+                endpoint,
+                NetMessage::TransferReject {
+                    file_name,
+                    reason: format!(
+                        "Exceeds max size ({})",
+                        crate::message::MAX_TRANSFER_DISPLAY_NAME
+                    ),
+                },
+            );
+            return;
+        }
+        self.state.set_pending_transfer_offer(PendingTransferOffer {
+            sender,
+            file_name: file_name.clone(),
+            file_size,
+        });
+        self.state.add_system_info_message(format!(
+            "incoming file '{}' ({} bytes) — type /accept <name> or /reject <name>",
+            file_name, file_size
+        ));
+    }
+
+    fn process_transfer_accept(&mut self, _endpoint: Endpoint, file_name: String) {
+        self.state.mark_outbound_transfer_accepted(&file_name);
+        self.state.add_system_info_message(format!("peer accepted transfer of '{}'", file_name));
+    }
+
+    fn process_transfer_reject(&mut self, _endpoint: Endpoint, file_name: String, reason: String) {
+        // Receiver side cleanup happens via /cancel or timeout.
+        self.state.add_system_warn_message(format!(
+            "transfer of '{}' rejected by peer: {}",
+            file_name, reason
+        ));
+    }
+
+    fn process_transfer_cancel(&mut self, _endpoint: Endpoint, file_name: String) {
+        self.state.clear_pending_transfer_offer();
+        self.state.add_system_info_message(format!("peer cancelled transfer of '{}'", file_name));
+    }
+
+    fn accept_transfer(&mut self, file_name: String) {
+        let Some(offer) = self.state.take_pending_transfer_offer() else {
+            self.state.add_system_warn_message("no pending transfer to accept".into());
+            return;
+        };
+        if offer.file_name != file_name {
+            self.state.add_system_warn_message(format!(
+                "pending transfer name mismatch: expected '{}', got '{}'",
+                offer.file_name, file_name
+            ));
+            self.state.set_pending_transfer_offer(offer);
+            return;
+        }
+        let sender_endpoint = self.state.peer_endpoint_by_name(&offer.sender);
+        match sender_endpoint {
+            Some(endpoint) => {
+                self.send_secure_to_peer(
+                    endpoint,
+                    NetMessage::TransferAccept { file_name: offer.file_name.clone() },
+                );
+            }
+            None => {
+                self.state.add_system_warn_message(format!(
+                    "unknown sender '{}'; transfer cancelled",
+                    offer.sender
+                ));
+                return;
+            }
+        }
+        let sanitized_user = sanitize_filename(&offer.sender);
+        let sanitized_file = sanitize_filename(&file_name);
+        let data_dir = self
+            .state
+            .downloads_base_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("triadchat/downloads")
+            .join(&sanitized_user);
+        let _ = std::fs::create_dir_all(&data_dir);
+        let unique_id = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        let temp_name = format!(".{}.tmp_{}", sanitized_file, unique_id);
+        let dl_path = data_dir.join(temp_name);
+        if let Ok(f) = std::fs::File::create(&dl_path) {
+            drop(f);
+        }
+        self.state.start_transfer(offer.sender.clone(), file_name.clone(), dl_path);
+        self.state.add_system_info_message(format!(
+            "accepted transfer of '{}' from {} ({} bytes)",
+            file_name, offer.sender, offer.file_size
+        ));
+    }
+
+    fn reject_transfer(&mut self, _file_name: String) {
+        let Some(offer) = self.state.take_pending_transfer_offer() else {
+            self.state.add_system_warn_message("no pending transfer to reject".into());
+            return;
+        };
+        let sender_endpoint = self.state.peer_endpoint_by_name(&offer.sender);
+        if let Some(endpoint) = sender_endpoint {
+            self.send_secure_to_peer(
+                endpoint,
+                NetMessage::TransferReject {
+                    file_name: offer.file_name.clone(),
+                    reason: "rejected by user".into(),
+                },
+            );
+        }
+        self.state.add_system_info_message(format!(
+            "rejected transfer of '{}' from {}",
+            offer.file_name, offer.sender
+        ));
+    }
+
     fn process_user_data(&mut self, user_name: &str, file_name: &str, chunk: Chunk) {
         use std::io::Write;
         let sanitized_user = sanitize_filename(user_name);
@@ -1611,39 +1760,20 @@ impl<'a> Application<'a> {
                 }
             }
             Chunk::Data(data) => {
-                let mut try_write = || -> Result<()> {
-                    let temp_path = if let Some(path) =
-                        self.state.get_transfer_temp_path(&sanitized_user, &sanitized_file)
-                    {
-                        path.clone()
-                    } else {
-                        let data_dir = self
-                            .state
-                            .downloads_base_dir()
-                            .unwrap_or_else(std::env::temp_dir)
-                            .join("triadchat/downloads")
-                            .join(&sanitized_user);
-                        std::fs::create_dir_all(&data_dir)?;
-
-                        let unique_id = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
-                        let temp_name = format!(".{}.tmp_{}", sanitized_file, unique_id);
-                        let temp_path = data_dir.join(temp_name);
-
-                        std::fs::OpenOptions::new()
-                            .create(true)
-                            .write(true)
-                            .truncate(true)
-                            .open(&temp_path)?;
-
-                        self.state.start_transfer(
-                            sanitized_user.clone(),
-                            sanitized_file.clone(),
-                            temp_path.clone(),
-                        );
-                        temp_path
+                let temp_path =
+                    match self.state.get_transfer_temp_path(&sanitized_user, &sanitized_file) {
+                        Some(path) => path.clone(),
+                        None => {
+                            self.state.add_system_warn_message(format!(
+                                "rejected unsolicited file chunk for '{}' from {}",
+                                sanitized_file, user_name
+                            ));
+                            return;
+                        }
                     };
 
-                    std::fs::OpenOptions::new().append(true).open(temp_path)?.write_all(&data)?;
+                let mut try_write = || -> Result<()> {
+                    std::fs::OpenOptions::new().append(true).open(&temp_path)?.write_all(&data)?;
                     self.state.record_transfer_bytes(
                         &sanitized_user,
                         &sanitized_file,
@@ -1663,6 +1793,22 @@ impl<'a> Application<'a> {
         chunk: Chunk,
         user_name: &str,
     ) {
+        let sanitized_user = sanitize_filename(user_name);
+        let sanitized_file = sanitize_filename(file_name);
+        if self.state.get_transfer_temp_path(&sanitized_user, &sanitized_file).is_none() {
+            let temp_dir = self
+                .state
+                .downloads_base_dir()
+                .unwrap_or_else(std::env::temp_dir)
+                .join("triadchat/downloads")
+                .join(&sanitized_user);
+            let _ = std::fs::create_dir_all(&temp_dir);
+            let unique_id = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+            let temp_name = format!(".{}.tmp_{}", sanitized_file, unique_id);
+            let temp_path = temp_dir.join(temp_name);
+            let _ = std::fs::File::create(&temp_path);
+            self.state.start_transfer(sanitized_user, sanitized_file, temp_path);
+        }
         self.process_user_data(user_name, file_name, chunk);
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod room_cmd;
 pub mod send_file;
 pub mod skill_cmd;
 pub mod summary_cmd;
+pub mod transfer_cmd;
 
 use std::collections::HashMap;
 
@@ -56,6 +57,8 @@ pub enum AppCommand {
     Skill { name: String, args: Vec<String> },
     RunProposal(usize),
     Cancel,
+    AcceptTransfer(String),
+    RejectTransfer(String),
     Avatar(AvatarCommandKind),
     ArtList,
     ArtReload,

--- a/src/commands/send_file.rs
+++ b/src/commands/send_file.rs
@@ -36,6 +36,8 @@ pub struct SendFile {
     progress_id: Option<usize>,
     encoder: Encoder,
     failed_endpoints: HashSet<Endpoint>,
+    offered: bool,
+    accepted: bool,
 }
 
 impl SendFile {
@@ -61,6 +63,8 @@ impl SendFile {
             progress_id: None,
             encoder: Encoder::new(),
             failed_endpoints: HashSet::new(),
+            offered: false,
+            accepted: false,
         })
     }
 }
@@ -70,6 +74,36 @@ impl Action for SendFile {
         if self.progress_id.is_none() {
             let id = state.add_progress_message(&self.file_name, self.file_size);
             self.progress_id = Some(id);
+        }
+
+        if !self.offered {
+            self.offered = true;
+            let user_name = state.local_user_name().to_string();
+            let offer = NetMessage::TransferOffer {
+                file_name: self.file_name.clone(),
+                file_size: self.file_size,
+                sender: user_name,
+            };
+            let message = self.encoder.encode(offer);
+            let endpoints: Vec<Endpoint> = state
+                .all_user_endpoints()
+                .into_iter()
+                .filter(|e| !self.failed_endpoints.contains(e))
+                .collect();
+            let result = crate::util::send_all(network, &endpoints, message);
+            if result.is_err() {
+                result.report_if_err(state);
+                return Processing::Completed;
+            }
+            return Processing::Partial(Duration::from_millis(50));
+        }
+
+        if !self.accepted {
+            if state.has_accepted_outbound_transfer(&self.file_name) {
+                self.accepted = true;
+            } else {
+                return Processing::Partial(Duration::from_millis(100));
+            }
         }
 
         let mut data = [0; Self::CHUNK_SIZE];

--- a/src/commands/transfer_cmd.rs
+++ b/src/commands/transfer_cmd.rs
@@ -1,0 +1,30 @@
+use crate::commands::{AppCommand, Command, ParsedCommand};
+use crate::util::Result;
+
+pub struct AcceptCommand;
+
+impl Command for AcceptCommand {
+    fn name(&self) -> &'static str {
+        "accept"
+    }
+
+    fn parse_params(&self, params: Vec<String>) -> Result<ParsedCommand> {
+        let filename =
+            params.first().ok_or_else(|| anyhow::anyhow!("usage: /accept <filename>"))?.clone();
+        Ok(ParsedCommand::App(AppCommand::AcceptTransfer(filename)))
+    }
+}
+
+pub struct RejectCommand;
+
+impl Command for RejectCommand {
+    fn name(&self) -> &'static str {
+        "reject"
+    }
+
+    fn parse_params(&self, params: Vec<String>) -> Result<ParsedCommand> {
+        let filename =
+            params.first().ok_or_else(|| anyhow::anyhow!("usage: /reject <filename>"))?.clone();
+        Ok(ParsedCommand::App(AppCommand::RejectTransfer(filename)))
+    }
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -105,6 +105,10 @@ pub enum NetMessage {
     PeerIdentity { public_key: Vec<u8>, signature: Vec<u8>, timestamp: u64 },
     KeyExchange { public_key: Vec<u8>, signature: Vec<u8> },
     Secure(Vec<u8>),
+    TransferOffer { file_name: String, file_size: u64, sender: String },
+    TransferAccept { file_name: String },
+    TransferReject { file_name: String, reason: String },
+    TransferCancel { file_name: String },
 }
 
 pub const MAX_NAME_LEN: usize = 256;
@@ -123,6 +127,8 @@ pub const MAX_AVATAR_LEN: usize = 65536; // 64 KB
 pub const MAX_ROOM_ID_LEN: usize = 256;
 pub const MAX_ROOM_MEMBERS: usize = 256;
 pub const MAX_SKILL_SUMMARY_LEN: usize = 65536; // 64 KB
+pub const MAX_TRANSFER_SIZE: u64 = 100 * 1024 * 1024; // 100 MB
+pub const MAX_TRANSFER_DISPLAY_NAME: &str = "100 MB";
 
 impl TodoItem {
     pub fn validate(&self) -> bool {
@@ -224,6 +230,14 @@ impl NetMessage {
                 public_key.len() == 32 && signature.len() == 64
             }
             NetMessage::Secure(data) => !data.is_empty(), // At minimum, 8B nonce + 16B tag
+            NetMessage::TransferOffer { file_name, file_size: _, sender } => {
+                file_name.len() <= MAX_FILE_NAME_LEN && sender.len() <= MAX_NAME_LEN
+            }
+            NetMessage::TransferAccept { file_name } => file_name.len() <= MAX_FILE_NAME_LEN,
+            NetMessage::TransferReject { file_name, reason: _ } => {
+                file_name.len() <= MAX_FILE_NAME_LEN
+            }
+            NetMessage::TransferCancel { file_name } => file_name.len() <= MAX_FILE_NAME_LEN,
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -46,6 +46,13 @@ pub struct ActiveTransferView {
     pub bytes_received: u64,
 }
 
+#[derive(Clone, Debug)]
+pub struct PendingTransferOffer {
+    pub sender: String,
+    pub file_name: String,
+    pub file_size: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AiMode {
@@ -170,6 +177,8 @@ pub struct State {
     trusted_peer_fingerprints: HashSet<String>,
     active_transfers: HashMap<(String, String), ActiveTransfer>,
     downloads_base_dir: Option<PathBuf>,
+    pending_transfer_offer: Option<PendingTransferOffer>,
+    accepted_outbound_transfers: HashSet<String>,
     verified_peer_fingerprints: HashMap<Endpoint, String>,
     signature_replay_cache: HashSet<Vec<u8>>,
     peer_public_keys: HashMap<Endpoint, Vec<u8>>,
@@ -220,6 +229,8 @@ impl Default for State {
             trusted_peer_fingerprints: HashSet::new(),
             active_transfers: HashMap::new(),
             downloads_base_dir: None,
+            pending_transfer_offer: None,
+            accepted_outbound_transfers: HashSet::new(),
             verified_peer_fingerprints: HashMap::new(),
             signature_replay_cache: HashSet::new(),
             peer_public_keys: HashMap::new(),
@@ -658,6 +669,30 @@ impl State {
 
     pub fn remove_transfer(&mut self, user: &str, filename: &str) -> Option<PathBuf> {
         self.active_transfers.remove(&(user.to_string(), filename.to_string())).map(|t| t.temp_path)
+    }
+
+    pub fn set_pending_transfer_offer(&mut self, offer: PendingTransferOffer) {
+        self.pending_transfer_offer = Some(offer);
+    }
+
+    pub fn pending_transfer_offer(&self) -> Option<&PendingTransferOffer> {
+        self.pending_transfer_offer.as_ref()
+    }
+
+    pub fn take_pending_transfer_offer(&mut self) -> Option<PendingTransferOffer> {
+        self.pending_transfer_offer.take()
+    }
+
+    pub fn clear_pending_transfer_offer(&mut self) {
+        self.pending_transfer_offer = None;
+    }
+
+    pub fn mark_outbound_transfer_accepted(&mut self, file_name: &str) {
+        self.accepted_outbound_transfers.insert(file_name.to_string());
+    }
+
+    pub fn has_accepted_outbound_transfer(&self, file_name: &str) -> bool {
+        self.accepted_outbound_transfers.contains(file_name)
     }
 
     /// Adds `bytes` to the per-transfer counter. No-op if no active transfer

--- a/tests/send_file.rs
+++ b/tests/send_file.rs
@@ -153,6 +153,17 @@ fn send_file() {
 
     sender.handle_input_line_for_test(&format!("/send {}", test_path.display())).unwrap();
 
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(5), |_, right| {
+        right.state().pending_transfer_offer().is_some()
+    });
+
+    receiver.handle_input_line_for_test("/accept test").unwrap();
+
+    for _ in 0..20 {
+        let _ = sender.process_next_event_with_timeout_for_test(Duration::from_millis(50));
+        let _ = receiver.process_next_event_with_timeout_for_test(Duration::from_millis(50));
+    }
+
     let received_path = std::env::temp_dir().join("triadchat/downloads").join("1").join("test");
     let expected_len = data.len() as u64;
     pump_until(&mut sender, &mut receiver, Duration::from_secs(20), |_, _| {
@@ -260,4 +271,100 @@ fn disconnected_user_clears_active_transfers() {
     app.disconnect_peer_for_test(endpoint);
 
     assert_eq!(tx_bytes(&app, "sender", "test.txt"), None);
+}
+
+#[test]
+fn transfer_reject_sends_rejection() {
+    let triadchat_dir = std::env::temp_dir().join("triadchat-reject");
+    let test_path = triadchat_dir.join("reject_test.bin");
+    let _ = std::fs::remove_dir_all(&triadchat_dir);
+    std::fs::create_dir_all(&triadchat_dir).unwrap();
+    let data = vec![88u8; 512];
+    std::fs::write(&test_path, &data).unwrap();
+
+    let discovery_port = 42000 + (rand::random::<u16>() % 1000);
+    let config1 = test_config("sender", discovery_port);
+    let config2 = test_config("receiver", discovery_port + 1);
+    let mut sender = Application::new_for_test(&config1).unwrap();
+    let mut receiver = Application::new_for_test(&config2).unwrap();
+
+    sender.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    receiver.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    sender.connect_peer_for_test(receiver.local_server_port_for_test().unwrap()).unwrap();
+
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(3), |left, right| {
+        left.state().peers().len() == 1 && right.state().peers().len() == 1
+    });
+
+    sender.handle_input_line_for_test(&format!("/send {}", test_path.display())).unwrap();
+
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(5), |_, right| {
+        right.state().pending_transfer_offer().is_some()
+    });
+
+    receiver.handle_input_line_for_test("/reject reject_test.bin").unwrap();
+
+    assert!(receiver.state().pending_transfer_offer().is_none());
+    let rendered = receiver
+        .state()
+        .messages()
+        .iter()
+        .map(|m| m.rendered_text())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("rejected transfer"), "got: {}", rendered);
+}
+
+#[test]
+fn unsolicited_chunk_rejected_without_offer() {
+    let mut config = Config::default();
+    config.ai.enabled = false;
+    let mut app = Application::new_for_test(&config).unwrap();
+    app.inject_authenticated_peer_for_test("attacker", "fp:attacker:test");
+
+    let endpoint = app.state().peer_endpoint_by_name("attacker").unwrap();
+    app.inject_network_message_for_test(
+        endpoint,
+        triadchat::message::NetMessage::UserData("evil.bin".into(), Chunk::Data(vec![0u8; 64])),
+    );
+
+    let rendered =
+        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    assert!(
+        rendered.contains("rejected unsolicited file chunk"),
+        "expected rejection warning, got: {}",
+        rendered
+    );
+}
+
+#[test]
+fn oversized_transfer_rejected() {
+    let mut config = Config::default();
+    config.ai.enabled = false;
+    let mut app = Application::new_for_test(&config).unwrap();
+    app.inject_authenticated_peer_for_test("sender", "fp:sender:oversized");
+
+    let endpoint = app.state().peer_endpoint_by_name("sender").unwrap();
+    app.inject_network_message_for_test(
+        endpoint,
+        triadchat::message::NetMessage::TransferOffer {
+            file_name: "huge.bin".into(),
+            file_size: 200 * 1024 * 1024, // 200 MB, exceeds 100 MB limit
+            sender: "sender".into(),
+        },
+    );
+
+    let rendered =
+        app.state().messages().iter().map(|m| m.rendered_text()).collect::<Vec<_>>().join("\n");
+    assert!(
+        rendered.contains("rejected: 209715200"),
+        "expected oversize rejection, got: {}",
+        rendered
+    );
+    assert!(
+        app.state().pending_transfer_offer().is_none(),
+        "oversized offer should not be stored as pending"
+    );
 }


### PR DESCRIPTION
## Summary

Replace push-only inbound file transfers with an offer/accept flow. Receivers must explicitly accept transfer offers before data is written to disk. Adds per-transfer size validation and `/accept` `/reject` commands.

## Changes

| File | Change |
|------|--------|
| `src/message.rs` | `TransferOffer`, `TransferAccept`, `TransferReject`, `TransferCancel` message types; `MAX_TRANSFER_SIZE` (100 MB) |
| `src/state.rs` | `PendingTransferOffer` struct + state management |
| `src/commands/transfer_cmd.rs` | `/accept <filename>` and `/reject <filename>` commands |
| `src/commands/send_file.rs` | SendFile sends offer first, waits for accept before sending chunks |
| `src/application/mod.rs` | Process offer/accept/reject/cancel; validate size; reject unsolicited chunks |
| `tests/send_file.rs` | 4 new tests: reject flow, unsolicited chunk rejection, oversized transfer, accept+transfer flow |

## Acceptance Criteria

- [x] Transfer offer sent before file data (consent required)
- [x] `/accept <filename>` creates download path and registers active transfer
- [x] `/reject <filename>` sends rejection to sender
- [x] Unsolicited file chunks rejected with warning
- [x] Transfers exceeding MAX_TRANSFER_SIZE (100 MB) auto-rejected
- [x] All 152 tests pass (110 unit + 42 integration)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

## New Tests (4)

| Test | Coverage |
|------|----------|
| `transfer_reject_sends_rejection` | User rejects offer → cleanup |
| `unsolicited_chunk_rejected_without_offer` | Chunks without offer → rejected |
| `oversized_transfer_rejected` | >100MB offer → auto-rejected |
| `send_file` (updated) | End-to-end offer → accept → transfer flow |

## Limitations

- Per-transfer quota only (total inbound not yet enforced)
- No rate-limiting on inbound chunks
- Cancel of in-progress transfer uses `/cancel` (existing flow)

## Risk

**Medium.** Changes the file transfer protocol — older peers need this version to send files. Backward compat with non-offer peers not implemented (will be rejected as unsolicited chunks).