### PR TITLE
fix: prevent TUI panics on tiny terminals (#109)

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -29,6 +29,12 @@ pub fn draw(
     language: &LanguageConfig,
     avatar_manager: &AvatarManager,
 ) {
+    // Too small to render a usable layout; skip drawing entirely rather than
+    // panicking on width/height underflow (e.g. tmux pane splits, tiny windows).
+    if chunk.width < 3 || chunk.height < 8 {
+        return;
+    }
+
     // Outer vertical split: [upper(min), input(6)]
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -196,15 +202,19 @@ fn add_progress_bar<'a>(
     progress: &'a ProgressState,
     theme: &Theme,
 ) -> Vec<Span<'a>> {
+    let width = panel_width.saturating_sub(20) as usize;
+    if width == 0 {
+        return Vec::new();
+    }
+
     let color = theme.progress_bar_color;
-    let width = (panel_width - 20) as usize;
 
     let (title, ui_current, ui_remaining) = match progress {
         ProgressState::Started(_) => ("Pending: ", 0, width),
         ProgressState::Working(total, current) => {
             let percentage = *current as f64 / *total as f64;
             let ui_current = (percentage * width as f64) as usize;
-            let ui_remaining = width - ui_current;
+            let ui_remaining = width.saturating_sub(ui_current);
             ("Sending: ", ui_current, ui_remaining)
         }
         ProgressState::Completed => ("Done! ", width, 0),
@@ -301,6 +311,14 @@ fn parse_content<'a>(content: &'a str, theme: &Theme, local_user_name: &str) -> 
 }
 
 fn draw_input_panel(frame: &mut Frame, state: &State, chunk: Rect, theme: &Theme) {
+    // Below 3 columns there is no room for the bordered inner area; draw only
+    // the border and skip content/cursor placement to avoid width underflow.
+    if chunk.width < 3 {
+        let border = Block::default().borders(Borders::ALL);
+        frame.render_widget(border, chunk);
+        return;
+    }
+
     let inner_width = (chunk.width - 2) as usize;
     let input = state.input().iter().collect::<String>();
     let input = split_each(input, inner_width)
@@ -326,8 +344,39 @@ fn draw_input_panel(frame: &mut Frame, state: &State, chunk: Rect, theme: &Theme
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Theme;
+    use crate::avatar::loader::AvatarManager;
+    use crate::config::{LanguageConfig, Theme};
+    use crate::state::State;
+    use ratatui::backend::TestBackend;
     use ratatui::style::Color;
+    use ratatui::Terminal;
+
+    #[test]
+    fn draw_never_panics_at_any_small_size() {
+        let theme = Theme::default();
+        let language = LanguageConfig::default();
+        let avatar_manager =
+            AvatarManager::new(std::path::PathBuf::from("/tmp/triadchat-test-avatars"));
+
+        for width in 0u16..=40 {
+            for height in 0u16..=40 {
+                let mut state = State::default();
+                // Include an active Progress message, which is rendered before
+                // Paragraph clipping and previously underflowed on tiny widths.
+                let idx = state.add_progress_message("payload.bin", 100);
+                state.progress_message_update(idx, 40);
+
+                let backend = TestBackend::new(width.max(1), height.max(1));
+                let mut terminal = Terminal::new(backend).unwrap();
+                terminal
+                    .draw(|frame| {
+                        let area = Rect::new(0, 0, width, height);
+                        draw(frame, &mut state, area, &theme, &language, &avatar_manager);
+                    })
+                    .unwrap();
+            }
+        }
+    }
 
     #[test]
     fn test_parse_content_no_mentions() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,6 +27,9 @@ pub fn send_all(
 // split messages to fit the width of the ui panel
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 pub fn split_each(input: String, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![input];
+    }
     let mut splitted = Vec::with_capacity(input.width() / width);
     let mut row = String::new();
 
@@ -109,5 +112,20 @@ impl Reportable for String {
 
     fn report_info(self, state: &mut State) {
         state.add_system_info_message(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_each;
+
+    #[test]
+    fn split_each_zero_width_does_not_divide_by_zero() {
+        assert_eq!(split_each("hello".to_string(), 0), vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn split_each_wraps_to_width() {
+        assert_eq!(split_each("abcd".to_string(), 2), vec!["ab".to_string(), "cd".to_string()]);
     }
 }


### PR DESCRIPTION
Closes #109

## Summary
Fixes critical (P0) panics when launching or resizing the terminal to a very small size. Integer underflow in width arithmetic crashed the app (debug: panic; release: corrupted layout), commonly triggered during tmux pane splitting.

## Root Causes & Fixes
| Site | Bug | Fix |
|------|-----|-----|
| `src/ui.rs` `add_progress_bar` | `(panel_width - 20)` u16 underflow when `panel_width < 20`, evaluated eagerly per `Progress` message before clipping | `panel_width.saturating_sub(20)`; return empty spans when result is 0; `saturating_sub` for remaining bar |
| `src/ui.rs` `draw_input_panel` | `(chunk.width - 2)` underflow when `chunk.width < 2` | Bail when `chunk.width < 3`; render only the border |
| `src/util.rs` `split_each` | `input.width() / width` divide-by-zero when `width == 0` | Return input unsplit when `width == 0` |
| `src/ui.rs` `draw` | No top-level guard; input/progress paths always rendered regardless of `should_show_side_panels` | Early-return when `width < 3 || height < 8` |

## Acceptance Criteria
- [x] App never panics for any `(width, height)` — verified exhaustively `(0,0)..=(40,40)`
- [x] `add_progress_bar` uses `saturating_sub(20)` and skips rendering when result is 0
- [x] `draw_input_panel` draws only the border when `chunk.width < 3`
- [x] Property/sweep test renders default state at every size with a `Progress` message present

## Tests
- `ui::tests::draw_never_panics_at_any_small_size` — exhaustive size sweep with active Progress message (regression, previously panicked at `ui.rs:200`)
- `util::tests::split_each_zero_width_does_not_divide_by_zero`
- `util::tests::split_each_wraps_to_width`

## Verification
```
cargo fmt --all -- --check      # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test --tests              # all pass
cargo build --release           # ok
```

## Risk / Limitations
- Terminals smaller than 3x8 render nothing (blank) instead of crashing — intentional per acceptance criteria. Layout returns immediately once the terminal grows back to a usable size.