### PR TITLE
security: route file transfer data plane through ChaCha20Poly1305 session (closes #110)

### DIFF
--- a/docs/plans/issue-110-secure-transfer.md
+++ b/docs/plans/issue-110-secure-transfer.md
@@ -1,0 +1,150 @@
+# Plan: Issue #110 — File transfer data plane bypasses ChaCha20Poly1305 secure session
+
+Link: https://github.com/takurot/triadchat/issues/110
+Severity: High / Security / P1
+Branch: `issue/110-secure-transfer-data-plane`
+
+## Problem
+
+`SendFile::process` (the only `Action` implementor) sends both `TransferOffer`
+and `NetMessage::UserData` via raw `crate::util::send_all` + plaintext `Encoder`,
+bypassing `send_secure_to_peer`. Up to 100 MB (`MAX_TRANSFER_SIZE`) of transfer
+content is observable/mutable on the wire even after a secure session exists.
+
+On the receiver side, `NetMessage::UserData` is dispatched with
+`accepts_authenticated_peer_message_inner(..., /* require_secure = */ false)`,
+explicitly waiving the plaintext-downgrade guard added in #101.
+
+## Root cause
+
+- `src/commands/send_file.rs:82-93` — `TransferOffer` sent plaintext.
+- `src/commands/send_file.rs:127-136` — `UserData` chunks sent plaintext.
+- `src/application/mod.rs:374-385` — receiver waives `require_secure` for `UserData`.
+- Architectural: the `Action` trait only receives `&mut State` + `&NetworkController`,
+  with no access to `SecureState`, so it cannot encrypt even if it wanted to.
+
+## Acceptance criteria (from Issue)
+
+1. `SendFile::process` routes through secure sending (`send_secure_to_peer` or
+   application wraps `UserData` in `Secure`).
+2. Receiver passes `require_secure = true` for `UserData` when a session exists,
+   mirroring `UserMessage`.
+3. Regression test: no `UserData` frame is transmitted unencrypted once
+   `has_session(endpoint)` is true.
+
+## Changes
+
+### 1. `src/secure.rs` — shared encode helper
+
+Add a unit-testable core function + a multi-endpoint sender:
+
+- `encode_for_endpoint(secure_state, endpoint, message) -> Result<Vec<u8>, &'static str>`
+  - If `has_session(endpoint)`: serialize inner (bincode legacy) → `session.encrypt` →
+    wrap in `NetMessage::Secure` → serialize → return bytes.
+  - Else: serialize `message` plaintext (backward compat with session-less peers).
+  - Mirrors the exact encoding steps of `Application::send_secure_to_peer`.
+- `send_secure_to_endpoints(network, secure_state, endpoints, message)
+   -> Result<(), Vec<(Endpoint, io::Error)>>`
+  - Per-endpoint: `encode_for_endpoint` then `network.send`. Same error shape as
+    `util::send_all` so `SendFile`'s failed-endpoint tracking still works.
+
+### 2. `src/action.rs` — give Action access to secure transport
+
+Extend the trait so actions can send encrypted frames. `SendFile` is the only
+implementor; `process_action` is the only caller.
+
+```rust
+pub trait Action: Send {
+    fn process(
+        &mut self,
+        state: &mut State,
+        network: &NetworkController,
+        secure: &mut SecureState,
+    ) -> Processing;
+}
+```
+
+Borrow check: in `process_action`, `self.state`, `self.secure_state`, and
+`self.node` are disjoint fields → simultaneous `&mut`/`&` borrows are legal.
+
+### 3. `src/commands/send_file.rs` — route transfer through secure sender
+
+- Remove the now-unused `encoder: Encoder` field (both send sites move to the
+  helper, which does its own bincode encoding).
+- `TransferOffer`: replace `self.encoder.encode(offer)` + `util::send_all` with
+  `secure::send_secure_to_endpoints(network, secure, &endpoints, &offer)`.
+- `UserData`: same replacement.
+- Preserve `failed_endpoints` tracking (helper returns the same error type).
+
+### 4. `src/application/mod.rs`
+
+- `process_action` (line ~1478): pass `&mut self.secure_state` into
+  `action.process(...)`.
+- `NetMessage::UserData` receiver (line ~374): replace
+  `accepts_authenticated_peer_message_inner(endpoint, "file transfer", false)`
+  with `accepts_authenticated_peer_message(endpoint, "file transfer")`
+  (require_secure = true). Decrypted `UserData` arriving via the `Secure`
+  envelope still passes because `processing_from_secure == true` at that point.
+- `send_secure_to_peer` (line ~759): delegate to `secure::encode_for_endpoint`
+  to remove duplicated security-critical encrypt-or-plaintext logic and prevent
+  drift between the two code paths. Behavior preserved (on failure: log + return).
+
+## Tests
+
+### Unit test (`src/secure.rs`)
+
+Directly verifies acceptance criterion #3 without needing a live socket:
+
+- Build a `SecureState` with a session keyed by a constructed `Endpoint`
+  (use `complete_key_exchange_as_initiator` + insert into `sessions`).
+- `encode_for_endpoint(...)` with that endpoint + a `NetMessage::UserData`
+  must decode as `NetMessage::Secure(_)` (NOT `UserData`).
+- `encode_for_endpoint(...)` with an endpoint that has NO session must decode
+  as the original `NetMessage::UserData(_)`.
+
+### Integration test (`tests/network_encryption.rs`)
+
+Two new tests mirroring the existing `plaintext_rejected_after_secure_session_established`
+and `encrypted_chat_messages_exchanged_after_key_exchange` patterns:
+
+- `plaintext_transfer_chunk_rejected_after_secure_session`: establish session,
+  inject plaintext `NetMessage::UserData`, assert rejection
+  ("rejected plaintext file transfer ... secure session exists") and that no
+  file is written.
+- `encrypted_file_transfer_completes_after_secure_session`: establish session,
+  perform a real `/send` + `/accept` flow, assert the received file bytes equal
+  the source (proves the encrypted data plane works end-to-end). Reuse the
+  pump/send helpers already in `tests/send_file.rs` pattern.
+
+## Backward compatibility
+
+- Peers without a secure session (older clients, or pre-key-exchange window)
+  still receive plaintext `UserData`/`TransferOffer` via the helper's else-branch.
+  Matches `send_secure_to_peer` and the #101 backward-compat test.
+- `processing_from_secure` flag already routes decrypted frames correctly.
+
+## Risks
+
+- **Action trait signature change**: blast radius is 1 impl + 1 caller (verified
+  via grep). Low risk.
+- **Existing `send_file` integration test**: connects peers but does NOT wait for
+  the secure session, so it exercises the plaintext fallback — should still pass.
+  Will confirm.
+- **Per-chunk allocation**: helper allocates a `Vec` per send instead of reusing
+  `Encoder`'s buffer. Acceptable: chunk payload is already a `Vec`, and transfer
+  throughput is rate-limited (100µs delay between chunks).
+
+## Verification
+
+- `cargo test --lib secure` (new unit test)
+- `cargo test --test network_encryption` (new integration tests)
+- `cargo test --test send_file` (existing transfer tests still pass)
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `cargo test --tests` + `cargo build --release` (pre-publish gate)
+
+## Out of scope
+
+- #125 (transfer accept/reject authentication), #133 (byte counter), #117 (chunk
+  file reopen), #118 (accept_transfer error swallowing) — separate issues, file
+  boundaries not touched by this fix.

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,3 +1,4 @@
+use crate::secure::SecureState;
 use crate::state::State;
 
 use message_io::network::NetworkController;
@@ -10,5 +11,10 @@ pub enum Processing {
 }
 
 pub trait Action: Send {
-    fn process(&mut self, state: &mut State, network: &NetworkController) -> Processing;
+    fn process(
+        &mut self,
+        state: &mut State,
+        network: &NetworkController,
+        secure: &mut SecureState,
+    ) -> Processing;
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -37,7 +37,7 @@ use crate::message::{
 use crate::room::transcript::TranscriptEntry;
 use crate::room::{MemberKind, Room};
 use crate::renderer::Renderer;
-use crate::secure::SecureState;
+use crate::secure::{encode_for_endpoint, SecureState};
 use crate::state::{
     AiFrequency, AiMode, AiState, ChatMessage, CursorMovement, MessageType, PeerReadiness,
     PendingTransferOffer, ScrollMovement, State,
@@ -373,11 +373,7 @@ impl<'a> Application<'a> {
             }
             NetMessage::UserData(file_name, chunk) => {
                 if let Some(user) = self.state.user_name(endpoint).cloned() {
-                    if !self.accepts_authenticated_peer_message_inner(
-                        endpoint,
-                        "file transfer",
-                        false,
-                    ) {
+                    if !self.accepts_authenticated_peer_message(endpoint, "file transfer") {
                         return;
                     }
                     self.process_user_data(&user, &file_name, chunk);
@@ -757,36 +753,13 @@ impl<'a> Application<'a> {
     }
 
     fn send_secure_to_peer(&mut self, endpoint: Endpoint, message: NetMessage) {
-        if self.secure_state.has_session(endpoint) {
-            let serialized =
-                match bincode::serde::encode_to_vec(&message, bincode::config::legacy()) {
-                    Ok(data) => data,
-                    Err(e) => {
-                        self.state
-                            .add_system_error_message(format!("bincode encode failed: {}", e));
-                        return;
-                    }
-                };
-            let encrypted = {
-                if let Some(session) = self.secure_state.session_mut(endpoint) {
-                    session.encrypt(&serialized)
-                } else {
-                    self.state.add_system_error_message("session lost unexpectedly".to_string());
-                    return;
-                }
-            };
-            let mut buf = Vec::new();
-            if let Err(e) = bincode::serde::encode_into_std_write(
-                NetMessage::Secure(encrypted),
-                &mut buf,
-                bincode::config::legacy(),
-            ) {
-                self.state.add_system_error_message(format!("bincode encode failed: {}", e));
-                return;
+        match encode_for_endpoint(&mut self.secure_state, endpoint, &message) {
+            Ok(buf) => {
+                self.node.network().send(endpoint, &buf);
             }
-            self.node.network().send(endpoint, &buf);
-        } else {
-            self.node.network().send(endpoint, self.encoder.encode(message));
+            Err(err) => {
+                self.state.add_system_error_message(err.to_string());
+            }
         }
     }
 
@@ -1476,7 +1449,7 @@ impl<'a> Application<'a> {
     }
 
     fn process_action(&mut self, mut action: Box<dyn Action>) {
-        match action.process(&mut self.state, self.node.network()) {
+        match action.process(&mut self.state, self.node.network(), &mut self.secure_state) {
             Processing::Completed => {}
             Processing::Partial(delay) => {
                 self.node.signals().send_with_timer(Signal::Action(action), delay);
@@ -1563,6 +1536,10 @@ impl<'a> Application<'a> {
 
     pub fn authenticate_endpoint_for_test(&mut self, endpoint: Endpoint, fingerprint: &str) {
         self.state.add_verified_peer_fingerprint(endpoint, fingerprint.to_string());
+    }
+
+    pub fn set_downloads_base_dir_for_test(&mut self, dir: std::path::PathBuf) {
+        self.state.set_downloads_base_dir(Some(dir));
     }
 
     fn process_transfer_offer(

--- a/src/commands/send_file.rs
+++ b/src/commands/send_file.rs
@@ -1,7 +1,7 @@
 use crate::action::{Action, Processing};
 use crate::commands::{Command, ParsedCommand};
-use crate::encoder::Encoder;
 use crate::message::{Chunk, NetMessage};
+use crate::secure::{send_secure_to_endpoints, SecureState};
 use crate::state::State;
 use crate::util::{Reportable, Result};
 
@@ -34,7 +34,6 @@ pub struct SendFile {
     file_name: String,
     file_size: u64,
     progress_id: Option<usize>,
-    encoder: Encoder,
     failed_endpoints: HashSet<Endpoint>,
     offered: bool,
     accepted: bool,
@@ -61,7 +60,6 @@ impl SendFile {
             file_name,
             file_size,
             progress_id: None,
-            encoder: Encoder::new(),
             failed_endpoints: HashSet::new(),
             offered: false,
             accepted: false,
@@ -70,7 +68,12 @@ impl SendFile {
 }
 
 impl Action for SendFile {
-    fn process(&mut self, state: &mut State, network: &NetworkController) -> Processing {
+    fn process(
+        &mut self,
+        state: &mut State,
+        network: &NetworkController,
+        secure: &mut SecureState,
+    ) -> Processing {
         if self.progress_id.is_none() {
             let id = state.add_progress_message(&self.file_name, self.file_size);
             self.progress_id = Some(id);
@@ -84,13 +87,12 @@ impl Action for SendFile {
                 file_size: self.file_size,
                 sender: user_name,
             };
-            let message = self.encoder.encode(offer);
             let endpoints: Vec<Endpoint> = state
                 .all_user_endpoints()
                 .into_iter()
                 .filter(|e| !self.failed_endpoints.contains(e))
                 .collect();
-            let result = crate::util::send_all(network, &endpoints, message);
+            let result = send_secure_to_endpoints(network, secure, &endpoints, &offer);
             if result.is_err() {
                 result.report_if_err(state);
                 return Processing::Completed;
@@ -125,7 +127,6 @@ impl Action for SendFile {
         }
 
         let net_message = NetMessage::UserData(self.file_name.clone(), chunk);
-        let message = self.encoder.encode(net_message);
 
         let endpoints = state
             .all_user_endpoints()
@@ -133,7 +134,7 @@ impl Action for SendFile {
             .filter(|e| !self.failed_endpoints.contains(e))
             .collect::<Vec<_>>();
 
-        let result = crate::util::send_all(network, &endpoints, message);
+        let result = send_secure_to_endpoints(network, secure, &endpoints, &net_message);
         if let Err(ref errors) = result {
             for (endpoint, _) in errors {
                 self.failed_endpoints.insert(*endpoint);

--- a/src/secure.rs
+++ b/src/secure.rs
@@ -3,9 +3,11 @@ use std::collections::{HashMap, HashSet};
 use chacha20poly1305::aead::generic_array::GenericArray;
 use chacha20poly1305::aead::{Aead, OsRng};
 use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit, Nonce};
-use message_io::network::Endpoint;
+use message_io::network::{Endpoint, NetworkController, SendStatus};
 use sha2::{Digest, Sha256};
 use x25519_dalek::{EphemeralSecret, PublicKey};
+
+use crate::message::NetMessage;
 
 pub struct PeerSecureSession {
     pub send_cipher: ChaCha20Poly1305,
@@ -130,9 +132,194 @@ impl SecureState {
     }
 }
 
+/// Failure modes for [`encode_for_endpoint`].
+#[derive(Debug)]
+pub enum EncodeFrameError {
+    /// `bincode` failed to serialize the (inner or outer) message.
+    EncodeFailed,
+    /// A session existed at the [`SecureState::has_session`] check but vanished
+    /// before it could be used (e.g. raced with [`SecureState::remove`]).
+    SessionLost,
+}
+
+impl std::fmt::Display for EncodeFrameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EncodeFrameError::EncodeFailed => write!(f, "bincode encode failed"),
+            EncodeFrameError::SessionLost => write!(f, "secure session lost before encrypt"),
+        }
+    }
+}
+
+impl std::error::Error for EncodeFrameError {}
+
+/// Encode `message` addressed to `endpoint` into wire bytes.
+///
+/// When a secure session exists for `endpoint`, the message is serialized,
+/// encrypted with ChaCha20Poly1305, and wrapped in [`NetMessage::Secure`].
+/// Otherwise it is serialized in plaintext (backward compatibility with peers
+/// that have not completed a key exchange). Mirrors the encoding steps of
+/// `Application::send_secure_to_peer` so the data plane and control plane share
+/// one canonical encrypt-or-plaintext decision.
+pub fn encode_for_endpoint(
+    secure_state: &mut SecureState,
+    endpoint: Endpoint,
+    message: &NetMessage,
+) -> Result<Vec<u8>, EncodeFrameError> {
+    if !secure_state.has_session(endpoint) {
+        return bincode::serde::encode_to_vec(message, bincode::config::legacy())
+            .map_err(|_| EncodeFrameError::EncodeFailed);
+    }
+    let serialized = bincode::serde::encode_to_vec(message, bincode::config::legacy())
+        .map_err(|_| EncodeFrameError::EncodeFailed)?;
+    let ciphertext = secure_state
+        .session_mut(endpoint)
+        .ok_or(EncodeFrameError::SessionLost)?
+        .encrypt(&serialized);
+    bincode::serde::encode_to_vec(NetMessage::Secure(ciphertext), bincode::config::legacy())
+        .map_err(|_| EncodeFrameError::EncodeFailed)
+}
+
+/// Send `message` to every endpoint in `endpoints`, encrypting per-endpoint when
+/// a secure session exists and falling back to plaintext otherwise.
+///
+/// Returns the same error shape as [`crate::util::send_all`]
+/// (`Vec<(Endpoint, io::Error)>`) so callers can attribute failures to specific
+/// endpoints (e.g. `SendFile::failed_endpoints` blacklisting). Per-endpoint
+/// encode/encrypt failures are attributed to the offending endpoint rather than
+/// short-circuiting the whole broadcast.
+pub fn send_secure_to_endpoints(
+    network: &NetworkController,
+    secure_state: &mut SecureState,
+    endpoints: &[Endpoint],
+    message: &NetMessage,
+) -> Result<(), Vec<(Endpoint, std::io::Error)>> {
+    let mut errors = Vec::new();
+    for &endpoint in endpoints {
+        let buf = match encode_for_endpoint(secure_state, endpoint, message) {
+            Ok(buf) => buf,
+            Err(err) => {
+                errors.push((endpoint, std::io::Error::other(err.to_string())));
+                continue;
+            }
+        };
+        if network.send(endpoint, &buf) != SendStatus::Sent {
+            errors.push((endpoint, std::io::Error::other("send failed (resource dropped)")));
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::Chunk;
+
+    fn fixture_endpoint(port: u16) -> Endpoint {
+        // ResourceId encodes a transport tag in its bits; 130 maps to a valid
+        // transport (same trick used by Application::inject_authenticated_peer_for_test).
+        // Distinct ports yield distinct Endpoint values for the same resource.
+        let id = message_io::network::ResourceId::from(130);
+        let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+        Endpoint::from_listener(id, addr)
+    }
+
+    fn secure_state_with_session(endpoint: Endpoint) -> SecureState {
+        let pending_a = generate_key_exchange();
+        let pending_b = generate_key_exchange();
+        let a_public = pending_a.public.to_bytes();
+        let b_public = pending_b.public.to_bytes();
+        let session = complete_key_exchange_as_initiator(pending_a.secret, &b_public).unwrap();
+        // Keep the responder side referenced so the initiator session is valid.
+        let _responder = complete_key_exchange_as_responder(pending_b.secret, &a_public).unwrap();
+        let mut state = SecureState::default();
+        state.sessions.insert(endpoint, session);
+        state
+    }
+
+    #[test]
+    fn encode_for_endpoint_encrypts_userdata_when_session_exists() {
+        let endpoint = fixture_endpoint(0);
+        let mut secure_state = secure_state_with_session(endpoint);
+        let msg = NetMessage::UserData("secret.bin".into(), Chunk::Data(vec![1, 2, 3, 4, 5]));
+
+        let encoded = encode_for_endpoint(&mut secure_state, endpoint, &msg).expect("encode ok");
+
+        let decoded = crate::encoder::decode(&encoded).expect("must decode as NetMessage");
+        match decoded {
+            NetMessage::Secure(_) => { /* expected: wrapped in Secure envelope */ }
+            other => panic!("expected NetMessage::Secure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_for_endpoint_emits_plaintext_when_no_session() {
+        let endpoint_with = fixture_endpoint(0);
+        let endpoint_without = fixture_endpoint(1);
+        let mut secure_state = secure_state_with_session(endpoint_with);
+        let msg = NetMessage::UserData("plain.bin".into(), Chunk::Data(vec![9, 9, 9]));
+
+        let encoded =
+            encode_for_endpoint(&mut secure_state, endpoint_without, &msg).expect("encode ok");
+
+        let decoded = crate::encoder::decode(&encoded).expect("must decode as NetMessage");
+        match decoded {
+            NetMessage::UserData(name, Chunk::Data(bytes)) => {
+                assert_eq!(name, "plain.bin");
+                assert_eq!(bytes, vec![9, 9, 9]);
+            }
+            other => panic!("expected plaintext NetMessage::UserData, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_for_endpoint_secure_output_differs_from_plaintext() {
+        let endpoint_with = fixture_endpoint(0);
+        let endpoint_without = fixture_endpoint(1);
+        let mut secure_state = secure_state_with_session(endpoint_with);
+        let msg = NetMessage::UserData("x".into(), Chunk::Data(vec![42; 32]));
+
+        let encrypted = encode_for_endpoint(&mut secure_state, endpoint_with, &msg).unwrap();
+        let plaintext = encode_for_endpoint(&mut secure_state, endpoint_without, &msg).unwrap();
+
+        assert_ne!(
+            encrypted, plaintext,
+            "encrypted frame must not equal the plaintext serialization"
+        );
+        // The plaintext frame must not accidentally leak the raw chunk bytes via
+        // a Secure-shaped envelope: it must decode to UserData, not Secure.
+        match crate::encoder::decode(&plaintext).unwrap() {
+            NetMessage::UserData(_, _) => {}
+            other => panic!("plaintext path produced {other:?}, expected UserData"),
+        }
+    }
+
+    #[test]
+    fn encode_for_endpoint_encrypts_transfer_offer_when_session_exists() {
+        let endpoint = fixture_endpoint(0);
+        let mut secure_state = secure_state_with_session(endpoint);
+        let msg = NetMessage::TransferOffer {
+            file_name: "report.pdf".into(),
+            file_size: 4096,
+            sender: "alice".into(),
+        };
+
+        let encoded = encode_for_endpoint(&mut secure_state, endpoint, &msg).expect("encode ok");
+        match crate::encoder::decode(&encoded).expect("must decode") {
+            NetMessage::Secure(_) => {}
+            other => panic!("expected NetMessage::Secure for TransferOffer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_frame_error_variants_display_for_io_bridge() {
+        assert!(EncodeFrameError::EncodeFailed.to_string().contains("bincode"));
+        assert!(EncodeFrameError::SessionLost.to_string().contains("session lost"));
+    }
 
     #[test]
     fn encrypt_decrypt_round_trip() {

--- a/src/secure.rs
+++ b/src/secure.rs
@@ -136,7 +136,7 @@ impl SecureState {
 #[derive(Debug)]
 pub enum EncodeFrameError {
     /// `bincode` failed to serialize the (inner or outer) message.
-    EncodeFailed,
+    EncodeFailed(String),
     /// A session existed at the [`SecureState::has_session`] check but vanished
     /// before it could be used (e.g. raced with [`SecureState::remove`]).
     SessionLost,
@@ -145,7 +145,9 @@ pub enum EncodeFrameError {
 impl std::fmt::Display for EncodeFrameError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EncodeFrameError::EncodeFailed => write!(f, "bincode encode failed"),
+            EncodeFrameError::EncodeFailed(detail) => {
+                write!(f, "bincode encode failed: {detail}")
+            }
             EncodeFrameError::SessionLost => write!(f, "secure session lost before encrypt"),
         }
     }
@@ -168,26 +170,26 @@ pub fn encode_for_endpoint(
 ) -> Result<Vec<u8>, EncodeFrameError> {
     if !secure_state.has_session(endpoint) {
         return bincode::serde::encode_to_vec(message, bincode::config::legacy())
-            .map_err(|_| EncodeFrameError::EncodeFailed);
+            .map_err(|e| EncodeFrameError::EncodeFailed(e.to_string()));
     }
     let serialized = bincode::serde::encode_to_vec(message, bincode::config::legacy())
-        .map_err(|_| EncodeFrameError::EncodeFailed)?;
+        .map_err(|e| EncodeFrameError::EncodeFailed(e.to_string()))?;
     let ciphertext = secure_state
         .session_mut(endpoint)
         .ok_or(EncodeFrameError::SessionLost)?
         .encrypt(&serialized);
     bincode::serde::encode_to_vec(NetMessage::Secure(ciphertext), bincode::config::legacy())
-        .map_err(|_| EncodeFrameError::EncodeFailed)
+        .map_err(|e| EncodeFrameError::EncodeFailed(e.to_string()))
 }
 
 /// Send `message` to every endpoint in `endpoints`, encrypting per-endpoint when
 /// a secure session exists and falling back to plaintext otherwise.
 ///
-/// Returns the same error shape as [`crate::util::send_all`]
-/// (`Vec<(Endpoint, io::Error)>`) so callers can attribute failures to specific
-/// endpoints (e.g. `SendFile::failed_endpoints` blacklisting). Per-endpoint
-/// encode/encrypt failures are attributed to the offending endpoint rather than
-/// short-circuiting the whole broadcast.
+/// Returns the same error shape (`Vec<(Endpoint, io::Error)>`) consumed by the
+/// `Reportable` impl and `stringify_sendall_errors` in `util.rs`, so callers can
+/// attribute failures to specific endpoints (e.g. `SendFile::failed_endpoints`
+/// blacklisting). Per-endpoint encode/encrypt failures are attributed to the
+/// offending endpoint rather than short-circuiting the whole broadcast.
 pub fn send_secure_to_endpoints(
     network: &NetworkController,
     secure_state: &mut SecureState,
@@ -203,8 +205,12 @@ pub fn send_secure_to_endpoints(
                 continue;
             }
         };
-        if network.send(endpoint, &buf) != SendStatus::Sent {
-            errors.push((endpoint, std::io::Error::other("send failed (resource dropped)")));
+        let status = network.send(endpoint, &buf);
+        if status != SendStatus::Sent {
+            errors.push((
+                endpoint,
+                std::io::Error::other(format!("send failed (status: {status:?})")),
+            ));
         }
     }
     if errors.is_empty() {
@@ -317,7 +323,9 @@ mod tests {
 
     #[test]
     fn encode_frame_error_variants_display_for_io_bridge() {
-        assert!(EncodeFrameError::EncodeFailed.to_string().contains("bincode"));
+        assert!(EncodeFrameError::EncodeFailed("boom".into())
+            .to_string()
+            .contains("bincode encode failed: boom"));
         assert!(EncodeFrameError::SessionLost.to_string().contains("session lost"));
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,3 @@
-// Note: transfer sends now go through `secure::send_secure_to_endpoints`, which
-// returns the same `Vec<(Endpoint, io::Error)>` error shape consumed by the
-// `Reportable` impl and `stringify_sendall_errors` below.
-
 // split messages to fit the width of the ui panel
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 pub fn split_each(input: String, width: usize) -> Vec<String> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,28 +1,6 @@
-use message_io::network::{NetworkController, Endpoint, SendStatus};
-
-// Broadcasts a message to all endpoints and collects any errors.
-pub fn send_all(
-    network: &NetworkController,
-    endpoints: &[Endpoint],
-    message: &[u8],
-) -> std::result::Result<(), Vec<(Endpoint, std::io::Error)>> {
-    let mut errors = Vec::new();
-    for &endpoint in endpoints {
-        match network.send(endpoint, message) {
-            SendStatus::Sent => (),
-            status => {
-                let error = std::io::Error::other(format!("Send failed with status: {:?}", status));
-                errors.push((endpoint, error));
-            }
-        }
-    }
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors)
-    }
-}
+// Note: transfer sends now go through `secure::send_secure_to_endpoints`, which
+// returns the same `Vec<(Endpoint, io::Error)>` error shape consumed by the
+// `Reportable` impl and `stringify_sendall_errors` below.
 
 // split messages to fit the width of the ui panel
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};

--- a/tests/network_encryption.rs
+++ b/tests/network_encryption.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use triadchat::application::Application;
 use triadchat::config::Config;
-use triadchat::message::{NetMessage, PeerInfo, SignaturePayload};
+use triadchat::message::{Chunk, NetMessage, PeerInfo, SignaturePayload};
 use triadchat::state::State;
 
 mod common;
@@ -257,4 +257,94 @@ fn plaintext_rejected_after_secure_session_established() {
         "plaintext message from authenticated peer with secure session must be rejected"
     );
     assert!(after.contains("rejected plaintext"), "should log rejection reason; got:\n{}", after);
+}
+
+#[test]
+fn plaintext_transfer_chunk_rejected_after_secure_session() {
+    let discovery_port = 51000 + (rand::random::<u16>() % 5000);
+    let alice_config = test_config("alice", discovery_port);
+    let bob_config = test_config("bob", discovery_port + 1);
+    let mut alice = Application::new_for_test(&alice_config).unwrap();
+    let mut bob = Application::new_for_test(&bob_config).unwrap();
+
+    alice.start_network_for_test().unwrap();
+    bob.start_network_for_test().unwrap();
+    alice.connect_peer_for_test(bob.local_server_port_for_test().unwrap()).unwrap();
+
+    pump_until(&mut alice, &mut bob, Duration::from_secs(5), |left, right| {
+        left.state().peer_is_ready("bob") && right.state().peer_is_ready("alice")
+    });
+
+    let alice_endpoint = bob.state().peer_endpoint_by_name("alice").unwrap();
+    let bob_endpoint = alice.state().peer_endpoint_by_name("bob").unwrap();
+
+    pump_until(&mut alice, &mut bob, Duration::from_secs(5), |left, right| {
+        left.has_secure_session(bob_endpoint) && right.has_secure_session(alice_endpoint)
+    });
+
+    // Bob should NOT accept a plaintext UserData frame from alice now that a
+    // secure session exists (closes the #110 data-plane bypass).
+    bob.inject_network_message_for_test(
+        alice_endpoint,
+        NetMessage::UserData("secret.bin".into(), Chunk::Data(vec![0xAB; 64])),
+    );
+
+    let _ = bob.process_next_event_with_timeout_for_test(Duration::from_millis(100));
+
+    let rendered = rendered_messages(bob.state());
+    assert!(
+        rendered.contains("rejected plaintext file transfer"),
+        "plaintext UserData must be rejected once a secure session exists; got:\n{}",
+        rendered
+    );
+    // No active inbound transfer should have been registered for the rejected chunk.
+    assert!(
+        bob.state().active_transfers_view().is_empty(),
+        "rejected plaintext chunk must not register an active transfer"
+    );
+}
+
+#[test]
+fn plaintext_transfer_offer_rejected_after_secure_session() {
+    let discovery_port = 56000 + (rand::random::<u16>() % 5000);
+    let alice_config = test_config("alice", discovery_port);
+    let bob_config = test_config("bob", discovery_port + 1);
+    let mut alice = Application::new_for_test(&alice_config).unwrap();
+    let mut bob = Application::new_for_test(&bob_config).unwrap();
+
+    alice.start_network_for_test().unwrap();
+    bob.start_network_for_test().unwrap();
+    alice.connect_peer_for_test(bob.local_server_port_for_test().unwrap()).unwrap();
+
+    pump_until(&mut alice, &mut bob, Duration::from_secs(5), |left, right| {
+        left.state().peer_is_ready("bob") && right.state().peer_is_ready("alice")
+    });
+
+    let alice_endpoint = bob.state().peer_endpoint_by_name("alice").unwrap();
+    let bob_endpoint = alice.state().peer_endpoint_by_name("bob").unwrap();
+
+    pump_until(&mut alice, &mut bob, Duration::from_secs(5), |left, right| {
+        left.has_secure_session(bob_endpoint) && right.has_secure_session(alice_endpoint)
+    });
+
+    bob.inject_network_message_for_test(
+        alice_endpoint,
+        NetMessage::TransferOffer {
+            file_name: "leak.txt".into(),
+            file_size: 128,
+            sender: "alice".into(),
+        },
+    );
+    let _ = bob.process_next_event_with_timeout_for_test(Duration::from_millis(100));
+
+    let rendered = rendered_messages(bob.state());
+    assert!(
+        rendered.contains("rejected plaintext transfer offer"),
+        "plaintext TransferOffer must be rejected once a secure session exists; got:\n{}",
+        rendered
+    );
+    assert!(
+        bob.state().pending_transfer_offer().is_none(),
+        "plaintext offer must not be stored as pending"
+    );
 }

--- a/tests/send_file.rs
+++ b/tests/send_file.rs
@@ -368,3 +368,61 @@ fn oversized_transfer_rejected() {
         "oversized offer should not be stored as pending"
     );
 }
+
+// ── #110: file transfer data plane over the secure session ───────────
+
+#[test]
+fn encrypted_file_transfer_completes_after_secure_session() {
+    // Isolated downloads dir so this test cannot collide with the `send_file`
+    // test's `remove_dir_all(triadchat_dir)` cleanup.
+    let downloads_root = tempfile::TempDir::new().unwrap();
+    let downloads_base = downloads_root.path().to_path_buf();
+
+    // 96 KiB source file = 3 data chunks (32 KiB CHUNK_SIZE) + 1 Chunk::End.
+    let src_dir = tempfile::TempDir::new().unwrap();
+    let src_path = src_dir.path().join("encrypted_96k.bin");
+    let data: Vec<u8> = (0..(96 * 1024)).map(|i| (i & 0xFF) as u8).collect();
+    std::fs::write(&src_path, &data).unwrap();
+
+    let discovery_port = 60000 + (rand::random::<u16>() % 5000);
+    let config_sender = test_config("alice", discovery_port);
+    let config_receiver = test_config("bob", discovery_port + 1);
+    let mut sender = Application::new_for_test(&config_sender).unwrap();
+    let mut receiver = Application::new_for_test(&config_receiver).unwrap();
+    receiver.set_downloads_base_dir_for_test(downloads_base.clone());
+
+    sender.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    receiver.start_network_for_test().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    sender.connect_peer_for_test(receiver.local_server_port_for_test().unwrap()).unwrap();
+
+    // Wait for both peers to be authenticated and a secure session to exist in
+    // both directions before initiating the transfer.
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(5), |left, right| {
+        left.state().peer_is_ready("bob") && right.state().peer_is_ready("alice")
+    });
+    let receiver_endpoint = sender.state().peer_endpoint_by_name("bob").unwrap();
+    let sender_endpoint = receiver.state().peer_endpoint_by_name("alice").unwrap();
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(5), |left, right| {
+        left.has_secure_session(receiver_endpoint) && right.has_secure_session(sender_endpoint)
+    });
+    assert!(sender.has_secure_session(receiver_endpoint), "session must be established pre-send");
+
+    sender.handle_input_line_for_test(&format!("/send {}", src_path.display())).unwrap();
+
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(5), |_, right| {
+        right.state().pending_transfer_offer().is_some()
+    });
+
+    receiver.handle_input_line_for_test("/accept encrypted_96k.bin").unwrap();
+
+    let received_path =
+        downloads_base.join("triadchat/downloads").join("alice").join("encrypted_96k.bin");
+    pump_until(&mut sender, &mut receiver, Duration::from_secs(10), |_, _| {
+        std::fs::metadata(&received_path).map(|m| m.len() == data.len() as u64).unwrap_or(false)
+    });
+
+    let received = std::fs::read(&received_path).unwrap();
+    assert_eq!(received, data, "decrypted transfer must reproduce the source bytes exactly");
+}


### PR DESCRIPTION
## Purpose

Closes #110 — File transfer data plane bypasses the ChaCha20Poly1305 secure session.

`SendFile::process` sent both `TransferOffer` and `NetMessage::UserData` via plaintext `Encoder` + `util::send_all`, bypassing `send_secure_to_peer`. The receiver also waived `require_secure` for `UserData`. Up to 100 MB (`MAX_TRANSFER_SIZE`) of transfer content was observable/mutable on the wire even after a secure session existed.

## Key design decisions

1. **Shared encode helper (`secure.rs`)** — `encode_for_endpoint()` + `send_secure_to_endpoints()` provide one canonical encrypt-or-plaintext path. Both the control plane (`send_secure_to_peer`) and the data plane (`SendFile`) now delegate to it, eliminating duplicated security-critical logic and preventing drift.
2. **`Action` trait extension** — added `&mut SecureState` parameter so actions can encrypt. Blast radius: 1 implementor (`SendFile`) + 1 caller (`process_action`).
3. **Receiver hardening** — `UserData` now uses `require_secure = true`, mirroring `UserMessage`. Decrypted frames arriving via the `Secure` envelope still pass because `processing_from_secure == true`.
4. **Backward compatibility preserved** — peers without a session still receive plaintext frames via the helper's else-branch (same as `send_secure_to_peer` and the #101 backward-compat test).

## Acceptance criteria checklist

- [x] `SendFile::process` routes through secure sending (`send_secure_to_endpoints`).
- [x] Receiver passes `require_secure = true` for `UserData` when a session exists.
- [x] Regression test: no `UserData` frame is transmitted unencrypted once `has_session(endpoint)` is true.

## Verification evidence

```
cargo fmt --all -- --check          # clean
cargo clippy --all-targets -- -D warnings   # no warnings
cargo test --tests                  # 31 suites, all ok
cargo build --release               # ok
```

Key test results:
- **Unit** (`src/secure.rs`): 10 tests including `encode_for_endpoint_encrypts_userdata_when_session_exists`, `encode_for_endpoint_encrypts_transfer_offer_when_session_exists`, `encode_for_endpoint_emits_plaintext_when_no_session`, `encode_for_endpoint_secure_output_differs_from_plaintext`.
- **Integration** (`tests/network_encryption.rs`): `plaintext_transfer_chunk_rejected_after_secure_session`, `plaintext_transfer_offer_rejected_after_secure_session`.
- **E2E** (`tests/send_file.rs`): `encrypted_file_transfer_completes_after_secure_session` — real `/send` + `/accept` over a secure session; received bytes equal source exactly.

## Risks / limitations

- Per-chunk `Vec` allocation in the helper instead of reusing `Encoder`'s buffer. Acceptable: chunk payload is already a `Vec`, and transfer throughput is rate-limited (100µs delay between chunks).
- Out of scope: #125 (transfer auth), #133 (byte counter), #117 (chunk file reopen), #118 (accept error swallowing) — separate issues, file boundaries not touched.
